### PR TITLE
Check if we have AppStream component ID

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -244,7 +244,7 @@ public class Slingshot.Widgets.AppEntry : Gtk.Button {
 
     private void uninstall_menuitem_activate () {
         var appcenter = Backend.AppCenter.get_default ();
-        if (appcenter.dbus == null) {
+        if (appcenter.dbus == null || appstream_comp_id == "") {
             return;
         }
 


### PR DESCRIPTION
Let's check if our the AppStream Component ID is not empty so we don't call `uninstall` on the AppCenter DBus with empty ID.