### PR TITLE
CMakeLists.txt: add missing -lm linker flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ include_directories (${CMAKE_BINARY_DIR}/lib/synapse-plugins)
 
 # Link some libraries
 add_definitions (${DEPS_CFLAGS} -DGMENU_I_KNOW_THIS_IS_UNSTABLE -include config.h)
-link_libraries (${DEPS_LIBRARIES})
+link_libraries (${DEPS_LIBRARIES} m)
 link_directories (${DEPS_LIBRARY_DIRS})
 
 # Installation


### PR DESCRIPTION
fedora has just introduced stricter linker flags, and it turns out, slingshot was missing the flag to be linked against libm.