### PR TITLE
Silence critical warnings on startup from DesktopFileInfo.vala

### DIFF
--- a/lib/synapse-core/desktop-file-service.vala
+++ b/lib/synapse-core/desktop-file-service.vala
@@ -189,9 +189,11 @@ namespace Synapse {
             } catch (Error err) {
                 string name = "Unidentified";
 
-                if (keyfile.has_key (GROUP, "Name")) {
-                    name = keyfile.get_string (GROUP, "Name");
-                }
+                try {
+                    if (keyfile.has_key (GROUP, "Name")) {
+                        name = keyfile.get_string (GROUP, "Name");
+                    }
+                } catch (GLib.KeyFileError e) {}
 
                 if (err is DesktopFileError.UNINTERESTING_ENTRY) {
                     debug ("Error initializing DesktopFileInfo from keyfile %s - %s", name, err.message);


### PR DESCRIPTION
Most warnings from DesktopFileInfo.init_from_keyfile () are not critical.  They have been downgraded to debug messages.  Any unanticipated error remains critical.

Some additional information is put in the error messages.