### PR TITLE
Silence warning re unrecognized X-Cinnamon environment.

### DIFF
--- a/lib/synapse-core/desktop-file-service.vala
+++ b/lib/synapse-core/desktop-file-service.vala
@@ -88,6 +88,7 @@ namespace Synapse {
                 string env_up = env.up ();
                 switch (env_up) {
                     case "GNOME":
+                    case "X-CINNAMON":
                         result |= EnvironmentType.GNOME;
                         break;
                     case "PANTHEON":


### PR DESCRIPTION
Recognize Cinnamon as a Gnome environment.

Is a separate environment enum entry required?