### PR TITLE
Allow to cycle the search results with arrows

### DIFF
--- a/src/Widgets/SearchView.vala
+++ b/src/Widgets/SearchView.vala
@@ -40,14 +40,12 @@ namespace Slingshot.Widgets {
                 uint n_children = get_children ().length ();
 
                 int current = selected.get_index ();
-                int target = 0;
+                int target = current + count;
 
-                if (count < 0 && current <= -count - 1) {
-                    target = (int)n_children - 1;
-                } else if (count > 0 && current >= n_children - count) {
-                    target = 0;
-                } else {
-                    target = current + count;
+                if (target < 0) {
+                    target = (int)n_children + count;
+                } else if (target >= n_children) {
+                    target = count - 1;
                 }
 
                 unowned Gtk.ListBoxRow? target_row = get_row_at_index (target);

--- a/src/Widgets/SearchView.vala
+++ b/src/Widgets/SearchView.vala
@@ -28,9 +28,39 @@ namespace Slingshot.Widgets {
         public signal void start_search (Synapse.SearchMatch search_match, Synapse.Match? target);
         public signal void app_launched ();
 
+        private class CycleListBox : Gtk.ListBox {
+            public override void move_cursor (Gtk.MovementStep step, int count) {
+                unowned Gtk.ListBoxRow selected = get_selected_row ();
+
+                if (step != Gtk.MovementStep.DISPLAY_LINES || selected == null) {
+                    base.move_cursor (step, count);
+                    return;
+                }
+
+                uint n_children = get_children ().length ();
+
+                int current = selected.get_index ();
+                int target = 0;
+
+                if (count < 0 && current <= -count - 1) {
+                    target = (int)n_children - 1;
+                } else if (count > 0 && current >= n_children - count) {
+                    target = 0;
+                } else {
+                    target = current + count;
+                }
+
+                unowned Gtk.ListBoxRow? target_row = get_row_at_index (target);
+                if (target_row != null) {
+                    select_row (target_row);
+                    target_row.grab_focus ();
+                }
+            }
+        }
+
         private Gtk.Stack stack;
         private Granite.Widgets.AlertView alert_view;
-        private Gtk.ListBox list_box;
+        private CycleListBox list_box;
         Gee.HashMap<SearchItem.ResultType, uint> limitator;
 
         private bool dragging = false;
@@ -45,7 +75,7 @@ namespace Slingshot.Widgets {
 
             // list box
             limitator = new Gee.HashMap<SearchItem.ResultType, uint> ();
-            list_box = new Gtk.ListBox ();
+            list_box = new CycleListBox ();
             list_box.activate_on_single_click = true;
             list_box.set_sort_func ((row1, row2) => update_sort (row1, row2));
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) update_header);


### PR DESCRIPTION
Fixes #95.

Allows to cycle search results with arrows. Creating another class just for this is required to override the `move_cursor` virtual signal and to access the base class.