### PR TITLE
prevent indicator from appearing in greeters

### DIFF
--- a/src/Slingshot.vala
+++ b/src/Slingshot.vala
@@ -168,8 +168,11 @@ public class Slingshot.Slingshot : Wingpanel.Indicator {
     }    
 }
 
-public Wingpanel.Indicator get_indicator (Module module) {
+public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
     debug ("Activating Slingshot");
+    if (server_type == Wingpanel.IndicatorManager.ServerType.GREETER){
+        return null;
+    }
     var indicator = new Slingshot.Slingshot ();
     return indicator;
 }


### PR DESCRIPTION
ISSUE:
Applications menu wingpanel indicator being displayed in login screen (greeter).
Users can for example open file manager and do read write operations **without** even loggin in.

EXPLAINATION:
Elementary lightdm greeter project at <https://github.com/elementary/greeter>   
file `src/Indicators/IndicatorBar.vala` calls  
 `Wingpanel.IndicatorManager.get_default ().initialize (Wingpanel.IndicatorManager.ServerType.GREETER);`
and displays all the indicators in the IndicatorManager which means all the indicators meant for ServerType GREETER.

the `initialize` method of Wingpanel.IndicatorManager in project <https://github.com/elementary/wingpanel> iterates through all the installed indicators and calls `get_indicator` method on each. The indicators whose `get_indicator` method return a non-null Indicator object are stored in the list of indicators of the IndicatorManager.

FIX:
So the fix is to return `null` from Sligshot.get_indicator method to prevent it from being displayed in greeters.