### PR TITLE
Fix page switcher not appearing first time when opening

### DIFF
--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -718,9 +718,9 @@ namespace Slingshot {
                 var app_entry = new Widgets.AppEntry (app);
                 app_entry.app_launched.connect (() => close_indicator ());
                 grid_view.append (app_entry);
-                app_entry.show_all ();
             }
 
+            grid_view.show_all ();
             stack.set_visible_child_name ("normal");
         }
 


### PR DESCRIPTION
Instead of showing only the app entries, show the entire grid so that the page switcher also appears correctly on the first launch.

There is a possibility that this could fix #112.