### PR TITLE
Hide org.gnome.Evince.desktop

### DIFF
--- a/data/pantheon-applications.menu
+++ b/data/pantheon-applications.menu
@@ -109,6 +109,7 @@
       <And>
         <Category>Graphics</Category>
         <Not><Filename>evince.desktop</Filename></Not>
+        <Not><Filename>org.gnome.Evince.desktop</Filename></Not>
       </And>
     </Include>
   </Menu> <!-- End Graphics -->
@@ -144,6 +145,7 @@
       <And>
         <Category>Office</Category>
         <Not><Filename>evince.desktop</Filename></Not>
+        <Not><Filename>org.gnome.Evince.desktop</Filename></Not>
       </And>
     </Include>
   </Menu> <!-- End Office -->
@@ -193,6 +195,7 @@
           <Filename>org.gnome.font-viewer.desktop</Filename>
           <Filename>gnome-font-viewer.desktop</Filename>
           <Filename>evince.desktop</Filename>
+          <Filename>org.gnome.Evince.desktop</Filename>
           <Filename>file-roller.desktop</Filename>
           <Filename>org.gnome.FileRoller.desktop</Filename>
         </Not>


### PR DESCRIPTION
Evince recently renamed this to the [app-id](https://gitlab.gnome.org/GNOME/evince/commit/47136ec9deb5d0a99125864107426cbc6ac0c38a) so in gnome 3.30 this was no longer hidden.