### PR TITLE
Include sub settings in search results

### DIFF
--- a/lib/synapse-plugins/switchboard-plugin.vala
+++ b/lib/synapse-plugins/switchboard-plugin.vala
@@ -105,7 +105,7 @@ namespace Synapse {
                 
                 // Using search to get sub settings
                 var sub_settings = new Gee.TreeMap<string, string?> (null, null);
-                var search_results = yield plug.search("");
+                var search_results = yield plug.search ("");
                 foreach (var result in search_results.entries) {
                     var title = result.key;
                     var view =  result.value;
@@ -116,18 +116,18 @@ namespace Synapse {
                     if (tmp.length > 2) continue;
                     
                     // get uri from plug's supported_settings
-                    string sub_uri = "";
+                    string? sub_uri = null;
                     foreach (var setting in settings.entries) {
                         if (setting.value == view) {
                             sub_uri = setting.key;
                             break;
                         }
                     }
-                    if (sub_uri == "") continue;
+                    if (sub_uri == null) continue;
                     
                     // ignore results pointing to the same uri
                     if (sub_settings.has_key(sub_uri)) continue;
-                    sub_settings.set(sub_uri, title);
+                    sub_settings[sub_uri] = title;
                     
                     plugs.add (new PlugInfo (title, "", plug.icon, sub_uri));
                 }

--- a/lib/synapse-plugins/switchboard-plugin.vala
+++ b/lib/synapse-plugins/switchboard-plugin.vala
@@ -99,9 +99,38 @@ namespace Synapse {
                 if (settings == null || settings.size <= 0) {
                     continue;
                 }
-
+                
                 string uri = settings.keys.to_array ()[0];
                 plugs.add (new PlugInfo (plug.display_name, plug.code_name, plug.icon, uri));
+                
+                // Using search to get sub settings
+                var sub_settings = new Gee.TreeMap<string, string?> (null, null);
+                var search_results = yield plug.search("");
+                foreach (var result in search_results.entries) {
+                    var title = result.key;
+                    var view =  result.value;
+                    if (view == "") continue;
+                    
+                    // ignore 3th level results
+                    string [] tmp = title.split(" → ");
+                    if (tmp.length > 2) continue;
+                    
+                    // get uri from plug's supported_settings
+                    string sub_uri = "";
+                    foreach (var setting in settings.entries) {
+                        if (setting.value == view) {
+                            sub_uri = setting.key;
+                            break;
+                        }
+                    }
+                    if (sub_uri == "") continue;
+                    
+                    // ignore results pointing to the same uri
+                    if (sub_settings.has_key(sub_uri)) continue;
+                    sub_settings.set(sub_uri, title);
+                    
+                    plugs.add (new PlugInfo (title, "", plug.icon, sub_uri));
+                }
             }
 
             // Unload all the plugs


### PR DESCRIPTION
See: #94 

While this gives us a quick win that doesn't require changes in Switchboard or all the Plugs it feels a bit fragile and technically unintuitive. An alternative approach would be adding an extra field to Switchboard.Plug that's used by the applications-menu. 

![screenshot from 2018-09-27 22-11-52](https://user-images.githubusercontent.com/523210/46172766-a09f0000-c2a4-11e8-8884-5d675d2b6e91.png)

It can give a lot of results so maybe I should alter the matching logic in such a way that it doesn't include the root name in the matching. 
![screenshot from 2018-09-27 22-13-16](https://user-images.githubusercontent.com/523210/46172765-a09f0000-c2a4-11e8-95c8-2392c9422b5b.png)