### PR TITLE
Refined sub settings search

### DIFF
--- a/lib/synapse-plugins/switchboard-plugin.vala
+++ b/lib/synapse-plugins/switchboard-plugin.vala
@@ -109,18 +109,19 @@ namespace Synapse {
                 foreach (var result in search_results.entries) {
                     var title = result.key;
                     var view =  result.value;
-                    if (view == "") continue;
                                         
                     // get uri from plug's supported_settings
-                    string? sub_uri = null;
-                    foreach (var setting in settings.entries) {
-                        if (setting.value == view) {
-                            sub_uri = setting.key;
-                            break;
+                    // Use main plug uri as fallback
+                    string sub_uri = uri;
+                    if (view != "") {
+                        foreach (var setting in settings.entries) {
+                            if (setting.value == view) {
+                                sub_uri = setting.key;
+                                break;
+                            }
                         }
                     }
-                    if (sub_uri == null) continue;
-                    
+
                     string[] path = title.split(" → ");
                     
                     plugs.add (new PlugInfo (title, "", plug.icon, sub_uri, path));


### PR DESCRIPTION
- Retaining more potential results
- More specific matching limiting actual results

This is an improvement on: https://github.com/elementary/applications-menu/pull/133
Started by some discussions at: https://github.com/elementary/switchboard-plug-keyboard/pull/176#issuecomment-426469609

## "Keyboard"
### Old
![old keyboard](https://user-images.githubusercontent.com/523210/46408564-cc8e0b80-c712-11e8-8344-e3537334be32.png)
### New
![new keyboard](https://user-images.githubusercontent.com/523210/46408382-4a054c00-c712-11e8-8948-fdb92697e11f.png)

## "Caps"
### Old
![old caps](https://user-images.githubusercontent.com/523210/46408567-cdbf3880-c712-11e8-8ce2-6cb3c4e9a94b.png)
### New
![new caps](https://user-images.githubusercontent.com/523210/46408381-4a054c00-c712-11e8-9273-f78a7118d17b.png)

## "default"
### Old
![old default](https://user-images.githubusercontent.com/523210/46408566-cd26a200-c712-11e8-9ca8-761daa847ebb.png)
### New
![new default](https://user-images.githubusercontent.com/523210/46408383-4a9de280-c712-11e8-90e7-5e7e175f4024.png)

I don't like the "default" results, not sure what to do about that. 
Maybe set a limit on the amount of results for the switchboard plugin? But that seems a bit arbitrary. 