### PR TITLE
Remove set to normal mode

### DIFF
--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -725,7 +725,6 @@ namespace Slingshot {
             }
 
             grid_view.show_all ();
-            stack.set_visible_child_name ("normal");
         }
 
         private void read_settings (bool first_start = false, bool check_columns = true, bool check_rows = true) {


### PR DESCRIPTION
Looks like for some reason populate_grid_view was resetting the category to the "normal" view when the application menu was opening.
No clue why it was added? 

Fixes: #146