### PR TITLE
Handle disabled Applications menu keyboard shortcut in tooltip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_definitions (-w)
 find_package (PkgConfig)
 
 # Check for Vala
- 
+
 pkg_check_modules(PLANK011 QUIET plank>=0.10.9)
 if (PLANK011_FOUND)
   set (PLANK_DEPS plank)
@@ -68,7 +68,7 @@ else ()
 endif ()
 
 set (CORE_DEPS "gobject-2.0;glib-2.0;gio-2.0;gio-unix-2.0;libsoup-2.4;gee-0.8;libgnome-menu-3.0;json-glib-1.0;${UNITY_DEPS};${PLANK_DEPS};appstream>=0.10.0;")
-set (UI_DEPS "wingpanel-2.0;gtk+-3.0>=3.12.0;granite>=5.2.0;${ZEITGEIST_DEPS};")
+set (UI_DEPS "wingpanel-2.0;gtk+-3.0>=3.12.0;granite>=5.2.1;${ZEITGEIST_DEPS};")
 
 pkg_check_modules (DEPS REQUIRED "${CORE_DEPS}${UI_DEPS}" gthread-2.0)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need the following dependencies:
 * libappstream-dev
 * libgee-0.8-dev
 * libgnome-menu-3-dev
-* libgranite-dev >= 5.2.0
+* libgranite-dev >= 5.2.1
 * libgtk-3-dev
 * libjson-glib-dev
 * libplank-dev

--- a/src/Slingshot.vala
+++ b/src/Slingshot.vala
@@ -108,14 +108,16 @@ public class Slingshot.Slingshot : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        if (keybinding_settings == null || indicator_grid == null) {
-            return;
+        string[] accels = {};
+
+        if (keybinding_settings != null && indicator_grid != null) {
+            var raw_accels = keybinding_settings.get_strv ("panel-main-menu");
+            foreach (string raw_accel in raw_accels) {
+                if (raw_accel != "") accels += raw_accel;
+            }
         }
 
-        string[] accels = keybinding_settings.get_strv ("panel-main-menu");
-        if (accels.length > 0) {
-            indicator_grid.tooltip_markup = Granite.markup_accel_tooltip (accels, _("Open and search apps"));
-        }
+        indicator_grid.tooltip_markup = Granite.markup_accel_tooltip (accels, _("Open and search apps"));
     }
 }
 
@@ -127,4 +129,3 @@ public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorMana
     var indicator = new Slingshot.Slingshot ();
     return indicator;
 }
-


### PR DESCRIPTION
I noticed the current tooltip would only be added when a accelerator was set. So I've switched to using the latest Granite accel utils where accels are optional and it always shows the description. 

But while doing this I noticed that when the keyboard shortcut was set to disabled `keybinding_settings.get_strv ("panel-main-menu");` would return an array with an empty string. This caused the original granite-accels to look like this when the shortcut was disabled:
![screenshot from 2018-12-07 12 36 37](https://user-images.githubusercontent.com/523210/49645842-8bb9b800-fa1d-11e8-9d0b-7c0f73376716.png)
To fix this it now ignores empty keybindings. 