### PR TITLE
Meson: install applications.menu using sysconfidr

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -5,5 +5,5 @@ install_data(
 
 install_data(
     'pantheon-applications.menu',
-    install_dir:join_paths('/etc', 'xdg', 'menus')
+    install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'menus')
 )


### PR DESCRIPTION
We've had Prefix-dependent defaults for sysconfdir since meson 0.44
so this is always preferred.

