### PR TITLE
Relax how app menu connects to the AppCenter DBus

### DIFF
--- a/src/Backend/AppCenter.vala
+++ b/src/Backend/AppCenter.vala
@@ -29,6 +29,7 @@ public interface AppCenterDBus : Object {
 public class Slingshot.Backend.AppCenter : Object {
     private const string DBUS_NAME = "io.elementary.appcenter";
     private const string DBUS_PATH = "/io/elementary/appcenter";
+    private const uint RECONNECT_TIMEOUT = 5000U;
 
     private static AppCenter? instance;
     public static unowned AppCenter get_default () {
@@ -43,19 +44,25 @@ public class Slingshot.Backend.AppCenter : Object {
 
     construct {
         Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.AUTO_START,
-                        name_appeared_callback, name_vanished_callback);
+                        () => try_connect (), name_vanished_callback);
     }
 
     private AppCenter () {
 
     }
 
-    private void name_appeared_callback (DBusConnection connection, string name, string name_owner) {
-        try {
-            dbus = Bus.get_proxy_sync (BusType.SESSION, DBUS_NAME, DBUS_PATH);
-        } catch (Error e) {
-            warning (e.message);
-        }
+    private void try_connect () {
+        Bus.get_proxy<AppCenterDBus> (BusType.SESSION, DBUS_NAME, DBUS_PATH, 0, null, (obj, res) => {
+            try {
+                dbus = Bus.get_proxy.end (res);
+            } catch (Error e) {
+                warning (e.message);
+                Timeout.add (RECONNECT_TIMEOUT, () => {
+                    try_connect ();
+                    return false;
+                });
+            }
+        });
     }
 
     private void name_vanished_callback (DBusConnection connection, string name) {


### PR DESCRIPTION
Should probably fix https://github.com/elementary/wingpanel/issues/196 and #190.
Do not connect to the AppCenter DBus synchronously and try to reconnect to it every 5 seconds if we fail. This will prevent from AppCenter waiting forever for the DBus to come up which can be quite a long time since AppCenter needs to collect all installed packages.

I noticed this accidentally when I got `AppEntry.vala:299: Exceeded waiting time` (the message is translated).