### PR TITLE
Use Idle.add () to launching app in SearchView

### DIFF
--- a/src/Widgets/SearchView.vala
+++ b/src/Widgets/SearchView.vala
@@ -79,21 +79,25 @@ namespace Slingshot.Widgets {
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) update_header);
             list_box.set_selection_mode (Gtk.SelectionMode.BROWSE);
             list_box.row_activated.connect ((row) => {
-                var search_item = row as SearchItem;
-                if (!dragging) {
-                    switch (search_item.result_type) {
-                        case SearchItem.ResultType.APP_ACTIONS:
-                        case SearchItem.ResultType.LINK:
-                        case SearchItem.ResultType.SETTINGS:
-                            search_item.app.match.execute (null);    
-                            break;
-                        default:
-                            search_item.app.launch ();
-                            break;
+                Idle.add (() => {
+                    var search_item = row as SearchItem;
+                    if (!dragging) {
+                        switch (search_item.result_type) {
+                            case SearchItem.ResultType.APP_ACTIONS:
+                            case SearchItem.ResultType.LINK:
+                            case SearchItem.ResultType.SETTINGS:
+                                search_item.app.match.execute (null);    
+                                break;
+                            default:
+                                search_item.app.launch ();
+                                break;
+                        }
+
+                        app_launched ();
                     }
 
-                    app_launched ();
-                }
+                    return false;
+                });
             });
 
             // Drag support

--- a/src/Widgets/SearchView.vala
+++ b/src/Widgets/SearchView.vala
@@ -114,13 +114,15 @@ namespace Slingshot.Widgets {
             list_box.drag_begin.connect ( (ctx) => {
                 var sr = list_box.get_selected_rows ();
                 if (sr.length () > 0) {
+                    dragging = true;
+
                     var di = (SearchItem)(sr.first ().data);
                     drag_uri = di.app_uri;
                     if (drag_uri != null) {
-                        dragging = true;
                         Gtk.drag_set_icon_gicon (ctx, di.icon.gicon, 16, 16);
-                        app_launched ();
                     }
+
+                    app_launched ();
                 }
             });
 


### PR DESCRIPTION
Using Idle.add () makes its actual launching occur after `drag_begin` signal is processed, so dragging from the search result no more launch the app.

Fixes #199.

This seems to work, but I am new to Vala / GTK so I don't know this use of Idle.add () is valid or not.  Also this fix assumes `drag_begin` signal is emitted before the idle function call. I don't know this is always true.