### PR TITLE
AppCenter: make the DBus calls asynchronous

### DIFF
--- a/src/Backend/AppCenter.vala
+++ b/src/Backend/AppCenter.vala
@@ -19,11 +19,11 @@
 
 [DBus (name = "io.elementary.appcenter")]
 public interface AppCenterDBus : Object {
-    public abstract void install (string component_id) throws GLib.Error;
-    public abstract void update (string component_id) throws GLib.Error;
-    public abstract void uninstall (string component_id) throws GLib.Error;
-    public abstract string get_component_from_desktop_id (string desktop_id) throws GLib.Error;
-    public abstract string[] search_components (string query) throws GLib.Error;
+    public abstract async void install (string component_id) throws GLib.Error;
+    public abstract async void update (string component_id) throws GLib.Error;
+    public abstract async void uninstall (string component_id) throws GLib.Error;
+    public abstract async string get_component_from_desktop_id (string desktop_id) throws GLib.Error;
+    public abstract async string[] search_components (string query) throws GLib.Error;
 }
 
 public class Slingshot.Backend.AppCenter : Object {
@@ -52,7 +52,7 @@ public class Slingshot.Backend.AppCenter : Object {
     }
 
     private void try_connect () {
-        Bus.get_proxy<AppCenterDBus> (BusType.SESSION, DBUS_NAME, DBUS_PATH, 0, null, (obj, res) => {
+        Bus.get_proxy.begin<AppCenterDBus> (BusType.SESSION, DBUS_NAME, DBUS_PATH, 0, null, (obj, res) => {
             try {
                 dbus = Bus.get_proxy.end (res);
             } catch (Error e) {


### PR DESCRIPTION
Prevents wingpanel from being unresponsive if AppCenter itself hangs