### PR TITLE
debian: drop Wnck

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Build-Depends: cmake (>= 2.6),
                libswitchboard-2.0-dev,
                libunity-dev,
                libwingpanel-2.0-dev,
-               libwnck-3-dev,
                libzeitgeist-2.0-dev,
                pkg-config,
                valac (>= 0.32.1)


### PR DESCRIPTION
It was removed a while ago in
* https://github.com/elementary/applications-menu/commit/985b050e0119e947d04e8cad09d1d706d58994e4