### PR TITLE
build: fix install path for wingpanel indicator

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,6 @@
 install_data(
     'io.elementary.desktop.wingpanel.applications-menu.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )
 
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,10 @@ asresources = gnome.compile_resources(
     c_name: 'as'
 )
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
 glib_dep = dependency('glib-2.0')
 gee_dep = dependency('gee-0.8')
 gio_dep = dependency('gio-2.0')

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,11 +43,13 @@ dependencies = [
     meson.get_compiler('vala').find_library('config', dirs: join_paths(meson.source_root(), 'vapi'))
 ]
 
+wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
+
 shared_module(
     meson.project_name(),
     sources,
     dependencies: dependencies,
     c_args : '-DGMENU_I_KNOW_THIS_IS_UNSTABLE',
     install: true,
-    install_dir: wingpanel_dep.get_pkgconfig_variable('indicatorsdir')
+    install_dir: wingpanel_indicatorsdir
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this wingpanel_dep.get_pkgconfig_variable will return a
path from within wingpanel's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.