### PR TITLE
SlingshotView: Stop hijacking Tab

### DIFF
--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -78,10 +78,10 @@ public class Slingshot.SlingshotView : Gtk.Grid {
         height_request = calculate_grid_height () + Pixels.BOTTOM_SPACE;
 
         var grid_image = new Gtk.Image.from_icon_name ("view-grid-symbolic", Gtk.IconSize.MENU);
-        grid_image .tooltip_text = _("View as Grid");
+        grid_image.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>1"}, _("View as Grid"));
 
         var category_image = new Gtk.Image.from_icon_name ("view-filter-symbolic", Gtk.IconSize.MENU);
-        category_image.tooltip_text = _("View by Category");
+        category_image.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>2"}, _("View by Category"));
 
         view_selector = new Granite.Widgets.ModeButton ();
         view_selector.margin_end = 12;
@@ -368,16 +368,6 @@ public class Slingshot.SlingshotView : Gtk.Grid {
                     return false;
                 }
                 search_entry.grab_focus ();
-                break;
-
-            case "Tab":
-                if (modality == Modality.NORMAL_VIEW) {
-                    view_selector.selected = (int) Modality.CATEGORY_VIEW;
-                    category_view.app_view.top_left_focus ();
-                } else if (modality == Modality.CATEGORY_VIEW) {
-                    view_selector.selected = (int) Modality.NORMAL_VIEW;
-                    grid_view.top_left_focus ();
-                }
                 break;
 
             case "Left":


### PR DESCRIPTION
The current Tab behavior is unexpected and goes against how Tab works in other parts of the UI. This branch stops hijacking Tab so that it moves focus as expected.

Also, while we're here we can markup the view switcher so that it's communicated what the proper shortcut is for view switching (consistent with apps)