### PR TITLE
SlingshotView: Remove redundant paste handler

### DIFF
--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -421,16 +421,6 @@ public class Slingshot.SlingshotView : Gtk.Grid {
                     category_view.app_view.top_left_focus ();
                 }
                 break;
-
-            case "v":
-            case "V":
-                if ((event.state & (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)) != 0) {
-                    search_entry.paste_clipboard ();
-                } else {
-                    return Gdk.EVENT_PROPAGATE;
-                }
-                break;
-
             default:
                 if (!search_entry.has_focus) {
                     search_entry.grab_focus ();


### PR DESCRIPTION
Pressing `Ctrl` always focuses the search entry so this is never actually used