### PR TITLE
Add View in Appcenter menuitem

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-# These are supported funding model platforms
-
-patreon: elementary
-custom: https://elementary.io/get-involved#funding

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -131,9 +131,9 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                     add (uninstall_menuitem);
 
                     if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
-                        var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in Appcenter"));
+                        var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in AppCenter"));
                         appcenter_menuitem.activate.connect (open_in_appcenter);
-                        
+
                         add (appcenter_menuitem);
                     }
 

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -20,6 +20,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
     public string desktop_id { get; construct; }
     public string desktop_path { get; construct; }
+    public DesktopAppInfo app_info { get; construct; }
 
     private bool has_system_item = false;
     private string appstream_comp_id = "";
@@ -49,7 +50,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 #endif
 
     construct {
-        var app_info = new DesktopAppInfo (desktop_id);
+        app_info = new DesktopAppInfo (desktop_id);
         foreach (unowned string _action in app_info.list_actions ()) {
             string action = _action.dup ();
             var menuitem = new Gtk.MenuItem.with_mnemonic (app_info.get_action_name (action));
@@ -112,7 +113,15 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         try {
             Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
         } catch (SpawnError e) {
-            debug ("Unable to open in Appcenter: %s\n", e.message);
+            var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                "Unable to open %s in AppCenter".printf (app_info.get_display_name ()),
+                "",
+                "dialog-error",
+                Gtk.ButtonsType.CLOSE
+            );
+            message_dialog.show_error_details (e.message);
+            message_dialog.run ();
+            message_dialog.destroy ();
         } finally {
             app_launched ();
         }

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -110,21 +110,23 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
     }
 
     private void open_in_appcenter () {
-        try {
-            GLib.AppInfo.launch_default_for_uri ("appstream://" + appstream_comp_id, null);
-        } catch (SpawnError e) {
-            var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                "Unable to open %s in AppCenter".printf (app_info.get_display_name ()),
-                "",
-                "dialog-error",
-                Gtk.ButtonsType.CLOSE
-            );
-            message_dialog.show_error_details (e.message);
-            message_dialog.run ();
-            message_dialog.destroy ();
-        } finally {
-            app_launched ();
-        }
+        AppInfo.launch_default_for_uri_async.begin ("appstream://" + appstream_comp_id, null, null, (obj, res) => {
+            try {
+                AppInfo.launch_default_for_uri_async.end (res);
+            } catch (Error error) {
+                var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                    "Unable to open %s in AppCenter".printf (app_info.get_display_name ()),
+                    "",
+                    "dialog-error",
+                    Gtk.ButtonsType.CLOSE
+                );
+                message_dialog.show_error_details (error.message);
+                message_dialog.run ();
+                message_dialog.destroy ();
+            } finally {
+                app_launched ();
+            }
+        });
     }
 
     private async void on_appcenter_dbus_changed (Backend.AppCenter appcenter) {

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -111,7 +111,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
     private async void on_appcenter_dbus_changed (Backend.AppCenter appcenter) {
         if (appcenter.dbus != null) {
             try {
-                debug ("Desktop ID" + desktop_id);
                 appstream_comp_id = yield appcenter.dbus.get_component_from_desktop_id (desktop_id);
                 if (appstream_comp_id != "") {
                     if (!has_system_item && get_children ().length () > 0) {
@@ -122,8 +121,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                     uninstall_menuitem.activate.connect (uninstall_menuitem_activate);
 
                     var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in Appcenter"));
-                    appcenter_menuitem.activate.connect (()=> {
-                        debug ("Desktop ID" + desktop_id + " => Appstream ComponentID " + appstream_comp_id);
+                    appcenter_menuitem.activate.connect (() => {
                         Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
                     });
 

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -136,7 +136,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                         appcenter_menuitem.activate.connect (open_in_appcenter);
                         add (appcenter_menuitem);
                     }
-                    
+
                     show_all ();
                 }
             } catch (GLib.Error e) {

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -132,8 +132,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
                     if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
                         var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in Appcenter"));
-
                         appcenter_menuitem.activate.connect (open_in_appcenter);
+                        
                         add (appcenter_menuitem);
                     }
 

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -113,6 +113,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
         } catch (SpawnError e) {
             debug ("Unable to open in Appcenter: %s\n", e.message);
+        } finally {
+            app_launched ();
         }
     }
 

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -20,7 +20,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
     public string desktop_id { get; construct; }
     public string desktop_path { get; construct; }
-    public DesktopAppInfo app_info { get; construct; }
+    private DesktopAppInfo app_info;
 
     private bool has_system_item = false;
     private string appstream_comp_id = "";
@@ -111,7 +111,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
     private void open_in_appcenter () {
         try {
-            Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
+            GLib.AppInfo.launch_default_for_uri ("appstream://" + appstream_comp_id, null);
         } catch (SpawnError e) {
             var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
                 "Unable to open %s in AppCenter".printf (app_info.get_display_name ()),

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -108,6 +108,14 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         });
     }
 
+    private void open_in_appcenter () {
+        try {
+            Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
+        } catch (SpawnError e) {
+            debug ("Unable to open in Appcenter: %s\n", e.message);
+        }
+    }
+
     private async void on_appcenter_dbus_changed (Backend.AppCenter appcenter) {
         if (appcenter.dbus != null) {
             try {
@@ -120,13 +128,14 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                     var uninstall_menuitem = new Gtk.MenuItem.with_label (_("Uninstall"));
                     uninstall_menuitem.activate.connect (uninstall_menuitem_activate);
 
-                    var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in Appcenter"));
-                    appcenter_menuitem.activate.connect (() => {
-                        Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
-                    });
-
                     add (uninstall_menuitem);
-                    add (appcenter_menuitem);
+
+                    if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
+                        var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in Appcenter"));
+
+                        appcenter_menuitem.activate.connect (open_in_appcenter);
+                        add (appcenter_menuitem);
+                    }
                     
                     show_all ();
                 }

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -111,6 +111,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
     private async void on_appcenter_dbus_changed (Backend.AppCenter appcenter) {
         if (appcenter.dbus != null) {
             try {
+                debug ("Desktop ID" + desktop_id);
                 appstream_comp_id = yield appcenter.dbus.get_component_from_desktop_id (desktop_id);
                 if (appstream_comp_id != "") {
                     if (!has_system_item && get_children ().length () > 0) {
@@ -120,7 +121,15 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                     var uninstall_menuitem = new Gtk.MenuItem.with_label (_("Uninstall"));
                     uninstall_menuitem.activate.connect (uninstall_menuitem_activate);
 
+                    var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in Appcenter"));
+                    appcenter_menuitem.activate.connect (()=> {
+                        debug ("Desktop ID" + desktop_id + " => Appstream ComponentID " + appstream_comp_id);
+                        Process.spawn_command_line_async ("xdg-open appstream://" + appstream_comp_id);
+                    });
+
                     add (uninstall_menuitem);
+                    add (appcenter_menuitem);
+                    
                     show_all ();
                 }
             } catch (GLib.Error e) {


### PR DESCRIPTION
Fixes https://github.com/elementary/applications-menu/issues/31 

Will work for all apps with valid component id when https://github.com/elementary/appcenter/pull/1078 is fixed. 

Doesn't show for snaps, appimages and apps invalid component id. 