### PR TITLE
Revert "CommandPlugin: Change to Action type"

### DIFF
--- a/src/synapse-plugins/command-plugin.vala
+++ b/src/synapse-plugins/command-plugin.vala
@@ -38,7 +38,7 @@ namespace Synapse {
             public CommandObject (string cmd) {
                 Object (title: _("Execute '%s'").printf (cmd), description: _("Run command"), command: cmd,
                         icon_name: "application-x-executable",
-                        match_type: MatchType.ACTION,
+                        match_type: MatchType.APPLICATION,
                         needs_terminal: cmd.has_prefix ("sudo "));
 
                 try {


### PR DESCRIPTION
Reverts elementary/applications-menu#284

Turns out this breaks actions