### PR TITLE
Switchboard: Put switchboard loading in a separate process

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,12 @@ add_project_arguments(
     language: 'c'
 )
 
+pluginsdir = join_paths(prefix, get_option('libdir'), 'io.elementary.application-menu')
+add_project_arguments(
+    '-DPLUGINSDIR="@0@"'.format(pluginsdir),
+    language: 'c'
+)
+
 glib_dep = dependency('glib-2.0')
 gee_dep = dependency('gee-0.8')
 gio_dep = dependency('gio-2.0')
@@ -41,6 +47,7 @@ zeitgeist_dep = dependency('zeitgeist-2.0')
 switchboard_dep = dependency('switchboard-2.0')
 libgnome_menu_dep = dependency('libgnome-menu-3.0')
 wingpanel_dep = dependency('wingpanel-2.0', version: '>=2.1.0')
+posix_dep = meson.get_compiler('vala').find_library('posix')
 
 unity_dep = []
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -81,7 +81,7 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
                 SearchItem.ResultType result_type = (SearchItem.ResultType) match.match_type;
                 if (match is Synapse.DesktopFilePlugin.ActionMatch) {
                     result_type = SearchItem.ResultType.APP_ACTIONS;
-                } else if (match is Synapse.SwitchboardPlugin.SwitchboardObject) {
+                } else if (match is Synapse.SwitchboardObject) {
                     result_type = SearchItem.ResultType.SETTINGS;
                 } else if (match is Synapse.LinkPlugin.Result) {
                     result_type = SearchItem.ResultType.INTERNET;

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,7 @@ sources = [
     'synapse-core/utils.vala',
     zeitgeist_backend_source,
 
+    'synapse-plugins/worker-link.vala',
     'synapse-plugins/calculator-plugin.vala',
     'synapse-plugins/command-plugin.vala',
     'synapse-plugins/desktop-file-plugin.vala',
@@ -73,7 +74,6 @@ dependencies = [
     granite_dep,
     gee_dep,
     gtk_dep,
-    switchboard_dep,
     json_glib_dep,
     zeitgeist_dep,
     libgnome_menu_dep,
@@ -82,6 +82,7 @@ dependencies = [
     plank_dep,
     unity_dep,
     wingpanel_dep,
+    posix_dep,
 ]
 
 wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
@@ -93,4 +94,19 @@ shared_module(
     c_args : '-DGMENU_I_KNOW_THIS_IS_UNSTABLE',
     install: true,
     install_dir: wingpanel_indicatorsdir
+)
+
+executable(
+    'switchboard-plugin',
+    'synapse-plugins/switchboard-plugin/plugin.vala',
+    dependencies: [
+        glib_dep,
+        gobject_dep,
+        gio_dep,
+        gio_unix_dep,
+        switchboard_dep,
+        gee_dep,
+    ],
+    install: true,
+    install_dir: pluginsdir
 )

--- a/src/synapse-plugins/switchboard-plugin.vala
+++ b/src/synapse-plugins/switchboard-plugin.vala
@@ -1,6 +1,5 @@
 /*
-* Copyright (c) 2015 Peter Arnold
-*               2017 elementary LLC.
+* Copyright 2020 elementary, Inc.
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -16,166 +15,149 @@
 * License along with this program; if not, write to the
 * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 * Boston, MA 02110-1301 USA
-*
-* Authored by: Peter Arnold
 */
+[CCode (cname = "PLUGINSDIR")]
+private extern const string PLUGINSDIR;
 
-namespace Synapse {
-    public class SwitchboardPlugin : Object, Activatable, ItemProvider {
-        public bool enabled { get; set; default = true; }
+public struct Synapse.PlugInfo {
+    public string title;
+    public string icon;
+    public string uri;
+    public string[] path;
+}
 
-        public SwitchboardPlugin () { }
+[DBus (name = "io.elementary.ApplicationMenu.Switchboard")]
+public class Synapse.SwitchboardExecutablePlugin : Object {
+    private Synapse.PlugInfo[] plugs;
 
-        public void activate () { }
+    public void set_plugs (Synapse.PlugInfo[] plugs) throws GLib.Error {
+        this.plugs = plugs;
+    }
 
-        public void deactivate () { }
+    [DBus (visible = false)]
+    public Synapse.PlugInfo[] get_plugs () {
+        return plugs;
+    }
+}
 
-        public class SwitchboardObject: Synapse.Match {
-            public string plug { get; construct set; }
-            public string uri { get; construct set; }
+public class Synapse.SwitchboardObject: Synapse.Match {
+    public string uri { get; construct set; }
 
-            public SwitchboardObject (PlugInfo plug_info) {
-                Object (
-                    title: plug_info.title,
-                    description: _("Open %s settings").printf (plug_info.title),
-                    plug: plug_info.code_name,
-                    icon_name: plug_info.icon,
-                    match_type: MatchType.APPLICATION,
-                    uri: plug_info.uri
-                );
+    public SwitchboardObject (Synapse.PlugInfo plug_info) {
+        Object (
+            title: plug_info.title,
+            description: _("Open %s settings").printf (plug_info.title),
+            icon_name: plug_info.icon,
+            match_type: MatchType.APPLICATION,
+            uri: plug_info.uri
+        );
+    }
+
+    public override void execute (Match? match) {
+        try {
+            Gtk.show_uri (null, "settings://%s".printf (uri), Gdk.CURRENT_TIME);
+        } catch (Error e) {
+            warning ("Failed to show URI for %s: %s\n".printf (uri, e.message));
+        }
+    }
+}
+
+public class Synapse.SwitchboardPlugin : Object, Activatable, ItemProvider {
+    static void register_plugin () {
+        DataSink.PluginRegistry.get_default ().register_plugin (
+            typeof (SwitchboardPlugin),
+            "Switchboard Search",
+            _("Find switchboard plugs and open them."),
+            "preferences-desktop",
+            register_plugin
+        );
+    }
+
+    static construct {
+        register_plugin ();
+    }
+
+    Synapse.WorkerLink worker_link;
+    GLib.Subprocess subprocess;
+    Synapse.SwitchboardExecutablePlugin executable_plugin;
+
+    construct {
+        executable_plugin = new Synapse.SwitchboardExecutablePlugin ();
+        worker_link = new Synapse.WorkerLink ();
+        worker_link.on_connection_accepted.connect ((connection) => {
+            try {
+                connection.register_object ("/io/elementary/applicationmenu", executable_plugin);
+            } catch (Error e) {
+                critical ("%s", e.message);
             }
+        });
 
-            public override void execute (Match? match) {
+        worker_link.start ();
+
+        var launcher = new GLib.SubprocessLauncher (GLib.SubprocessFlags.NONE);
+        string[] argv = {
+            GLib.Path.build_filename (PLUGINSDIR, "switchboard-plugin"),
+            "--dbus-address=%s".printf (worker_link.address)
+        };
+        try {
+            subprocess = launcher.spawnv (argv);
+            subprocess.wait_check_async.begin (null, (obj, res) => {
                 try {
-                    Gtk.show_uri (null, "settings://%s".printf (uri), Gdk.CURRENT_TIME);
-                } catch (Error e) {
-                    warning ("Failed to show URI for %s: %s\n".printf (uri, e.message));
+                    subprocess.wait_check_async.end (res);
+                } catch (GLib.Error e) {
+                    critical ("%s", e.message);
+                }
+
+                subprocess = null;
+            });
+        } catch (Error e) {
+            warning ("Failed to spawn %s", e.message);
+        }
+
+    }
+
+    ~SwitchboardPlugin () {
+        if (subprocess != null) {
+            subprocess.force_exit ();
+        }
+    }
+
+    public bool enabled { get; set; default = true; }
+
+    public void activate () { }
+
+    public void deactivate () { }
+
+    public async ResultSet? search (Query q) throws SearchError {
+        var plugs = executable_plugin.get_plugs ();
+
+        var result = new ResultSet ();
+        MatcherFlags flags;
+        if (q.query_string.length == 1) {
+            flags = MatcherFlags.NO_SUBSTRING | MatcherFlags.NO_PARTIAL | MatcherFlags.NO_FUZZY;
+        } else {
+            flags = 0;
+        }
+        var matchers = Query.get_matchers_for_query (q.query_string_folded, flags);
+
+        string stripped = q.query_string.strip ();
+        if (stripped == "") {
+            return null;
+        }
+
+        foreach (unowned Synapse.PlugInfo plug in plugs) {
+            // Retrieve the string that this plug/setting can be searched by
+            string searchable_name = plug.path.length > 0 ? plug.path[plug.path.length - 1] : plug.title;
+            foreach (var matcher in matchers) {
+                MatchInfo info;
+                if (matcher.key.match (searchable_name.down (), 0, out info)) {
+                    result.add (new SwitchboardObject (plug), Match.Score.AVERAGE + Match.Score.INCREMENT_MEDIUM);
+                    break;
                 }
             }
         }
+        q.check_cancellable ();
 
-        static void register_plugin () {
-            DataSink.PluginRegistry.get_default ().register_plugin (
-                typeof (SwitchboardPlugin),
-                "Switchboard Search",
-                _("Find switchboard plugs and open them."),
-                "preferences-desktop",
-                register_plugin
-            );
-        }
-
-        static construct {
-            register_plugin ();
-        }
-        private Gee.ArrayList<PlugInfo> plugs;
-
-        construct {
-            plugs = new Gee.ArrayList<PlugInfo> ();
-            load_plugs.begin ();
-        }
-
-        public class PlugInfo : GLib.Object {
-            public string title { get; construct set; }
-            public string code_name { get; construct set; }
-            public string icon { get; construct set; }
-            public string uri { get; construct set; }
-            public string[] path { get; construct set; }
-
-            public PlugInfo (string plug_title, string code_name, string icon, string uri, string[] path = {}) {
-                Object (title: plug_title, code_name: code_name, icon: icon, uri: uri, path: path);
-            }
-        }
-
-        private bool loading_in_progress = false;
-        public signal void load_complete ();
-
-        private async void load_plugs () {
-            loading_in_progress = true;
-            Idle.add_full (Priority.LOW, load_plugs.callback);
-            yield;
-
-            var plugs_manager = Switchboard.PlugsManager.get_default ();
-            foreach (var plug in plugs_manager.get_plugs ()) {
-                var settings = plug.supported_settings;
-                if (settings == null || settings.size <= 0) {
-                    continue;
-                }
-
-                string uri = settings.keys.to_array ()[0];
-                plugs.add (new PlugInfo (plug.display_name, plug.code_name, plug.icon, uri));
-
-                // Using search to get sub settings
-                var search_results = yield plug.search ("");
-                foreach (var result in search_results.entries) {
-                    var title = result.key;
-                    var view = result.value;
-
-                    // get uri from plug's supported_settings
-                    // Use main plug uri as fallback
-                    string sub_uri = uri;
-                    if (view != "") {
-                        foreach (var setting in settings.entries) {
-                            if (setting.value == view) {
-                                sub_uri = setting.key;
-                                break;
-                            }
-                        }
-                    }
-
-                    string[] path = title.split (" → ");
-
-                    plugs.add (new PlugInfo (title, "", plug.icon, sub_uri, path));
-                }
-            }
-
-            // Unload all the plugs
-            plugs_manager.unref ();
-
-            loading_in_progress = false;
-            load_complete ();
-        }
-
-        public async ResultSet? search (Query q) throws SearchError {
-            if (loading_in_progress) {
-                // wait
-                ulong signal_id = this.load_complete.connect (() => {
-                    search.callback ();
-                });
-                yield;
-                SignalHandler.disconnect (this, signal_id);
-            } else {
-                Idle.add_full (Priority.HIGH_IDLE, search.callback);
-                yield;
-            }
-
-            var result = new ResultSet ();
-            MatcherFlags flags;
-            if (q.query_string.length == 1) {
-                flags = MatcherFlags.NO_SUBSTRING | MatcherFlags.NO_PARTIAL | MatcherFlags.NO_FUZZY;
-            } else {
-                flags = 0;
-            }
-            var matchers = Query.get_matchers_for_query (q.query_string_folded, flags);
-
-            string stripped = q.query_string.strip ();
-            if (stripped == "") {
-                return null;
-            }
-
-            foreach (var plug in plugs) {
-                // Retrieve the string that this plug/setting can be searched by
-                string searchable_name = plug.path.length > 0 ? plug.path[plug.path.length - 1] : plug.title;
-                foreach (var matcher in matchers) {
-                    MatchInfo info;
-                    if (matcher.key.match (searchable_name.down (), 0, out info)) {
-                        result.add (new SwitchboardObject (plug), Match.Score.AVERAGE + Match.Score.INCREMENT_MEDIUM);
-                        break;
-                    }
-                }
-            }
-            q.check_cancellable ();
-
-            return result;
-        }
+        return result;
     }
 }

--- a/src/synapse-plugins/switchboard-plugin/plugin.vala
+++ b/src/synapse-plugins/switchboard-plugin/plugin.vala
@@ -1,0 +1,143 @@
+/*
+* Copyright 2020 elementary, Inc.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+[CCode (cname = "GETTEXT_PACKAGE")]
+private extern const string GETTEXT_PACKAGE;
+
+private static string? dbus_address = null;
+private const GLib.OptionEntry[] OPTIONS = {
+    { "dbus-address", 0, 0, OptionArg.STRING, ref dbus_address, "D-Bus server address", "ADDRESS" },
+    { null }
+};
+
+public struct PlugInfo {
+    public string title;
+    public string icon;
+    public string uri;
+    public string[] path;
+}
+
+public class SwitchboardPlugin : GLib.Object {
+    private GLib.MainLoop main_loop;
+    private GLib.DBusConnection connection;
+
+    const string DBUS_INTERFACE = "io.elementary.ApplicationMenu.Switchboard";
+    const string DBUS_PATH = "/io/elementary/applicationmenu";
+
+    construct {
+        main_loop = new GLib.MainLoop ();
+
+        debug ("Connecting to %s", dbus_address);
+
+        try {
+            connection = new DBusConnection.for_address_sync (
+                dbus_address,
+                GLib.DBusConnectionFlags.AUTHENTICATION_CLIENT | GLib.DBusConnectionFlags.DELAY_MESSAGE_PROCESSING
+            );
+            connection.start_message_processing ();
+        } catch (Error e) {
+            error ("D-Bus failure: %s", e.message);
+        }
+
+        load_plugs.begin ();
+        main_loop.run ();
+    }
+
+    private async void load_plugs () {
+        var plugs_manager = Switchboard.PlugsManager.get_default ();
+        Variant[] children = {};
+        foreach (var plug in plugs_manager.get_plugs ()) {
+            var settings = plug.supported_settings;
+            if (settings == null || settings.size <= 0) {
+                continue;
+            }
+
+            string uri = settings.keys.to_array ()[0];
+            var plug_info = PlugInfo () {
+                title = plug.display_name,
+                icon = plug.icon,
+                uri = uri,
+                path = {}
+            };
+            children += plug_info;
+
+            // Using search to get sub settings
+            var search_results = yield plug.search ("");
+            foreach (var result in search_results.entries) {
+                unowned string title = result.key;
+                var view = result.value;
+
+                // get uri from plug's supported_settings
+                // Use main plug uri as fallback
+                string sub_uri = uri;
+                if (view != "") {
+                    foreach (var setting in settings.entries) {
+                        if (setting.value == view) {
+                            sub_uri = setting.key;
+                            break;
+                        }
+                    }
+                }
+
+                string[] path = title.split (" → ");
+
+                plug_info = PlugInfo () {
+                    title = title,
+                    icon = plug.icon,
+                    uri = (owned) sub_uri,
+                    path = (owned) path
+                };
+                children += plug_info;
+            }
+        }
+
+        var parameters = new Variant.tuple ({new Variant.array (new GLib.VariantType ("(sssas)"), children)});
+        try {
+            connection.call_sync (null, DBUS_PATH, DBUS_INTERFACE, "SetPlugs", parameters, null, GLib.DBusCallFlags.NO_AUTO_START, -1);
+        } catch (GLib.Error e) {
+            critical (e.message);
+        }
+
+        main_loop.quit ();
+    }
+}
+
+public static int main (string[] args) {
+    Intl.setlocale (LocaleCategory.ALL, "");
+    Intl.textdomain (GETTEXT_PACKAGE);
+
+    try {
+        var opt_context = new GLib.OptionContext ("Plugin options");
+        opt_context.set_help_enabled (true);
+        opt_context.add_main_entries (OPTIONS, null);
+        opt_context.parse (ref args);
+    } catch (GLib.OptionError e) {
+        printerr ("error: %s\n", e.message);
+        printerr ("Run '%s --help' to see a full list of available command line options.\n", args[0]);
+        return 1;
+    }
+
+    if (dbus_address == null) {
+        printerr ("The --dbus-address argument is mandatory\n");
+        return 1;
+    }
+
+    new SwitchboardPlugin ();
+    return 0;
+}

--- a/src/synapse-plugins/worker-link.vala
+++ b/src/synapse-plugins/worker-link.vala
@@ -1,0 +1,92 @@
+/*
+* Copyright 2020 elementary, Inc.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+public class Synapse.WorkerLink : GLib.Object {
+    public string address { get; private set; }
+    private GLib.DBusServer dbus_server;
+    private GLib.DBusAuthObserver auth_observer;
+
+    public signal void on_connection_accepted (GLib.DBusConnection connection);
+
+    construct {
+        if (GLib.UnixSocketAddress.abstract_names_supported ()) {
+            address = "unix:abstract=/tmp/applications-menu-%u".printf ((uint)Posix.getpid ());
+        } else {
+            try {
+                var tmpdir = GLib.DirUtils.make_tmp ("applications-menu-XXXXXX");
+                address = "unix:tmpdir=%s".printf (tmpdir);
+            } catch (Error e) {
+                error ("Failed to determine temporary directory for D-Bus: %s", e.message);
+            }
+        }
+
+        var guid = GLib.DBus.generate_guid ();
+        auth_observer = new GLib.DBusAuthObserver ();
+        auth_observer.allow_mechanism.connect ((mechanism) => {
+            return mechanism == "EXTERNAL";
+        });
+
+        auth_observer.authorize_authenticated_peer.connect ((stream, credentials) => {
+            if (credentials == null) {
+                return false;
+            }
+
+            var own_credentials = new GLib.Credentials ();
+            try {
+                return credentials.is_same_user (own_credentials);
+            } catch (GLib.Error e) {
+                return false;
+            }
+        });
+
+        try {
+            dbus_server = new GLib.DBusServer.sync (
+                address,
+                GLib.DBusServerFlags.NONE,
+                guid,
+                auth_observer,
+                null
+            );
+            dbus_server.new_connection.connect ((connection) => {
+                connection.exit_on_close = false;
+                unowned GLib.Credentials? credentials = connection.get_peer_credentials ();
+                if (credentials == null) {
+                    return false;
+                }
+
+                try {
+                    credentials.get_unix_user ();
+                } catch (GLib.Error e) {
+                    return false;
+                }
+
+                on_connection_accepted (connection);
+                return true;
+            });
+        } catch (Error e) {
+            error ("Failed to create D-Bus server: %s", e.message);
+        }
+
+    }
+
+    public void start () {
+        debug ("D-Bus Server listening at %s", address);
+        dbus_server.start ();
+    }
+}


### PR DESCRIPTION
This allows to put all the switchboard compatibility layer in a throwable subprocess and thus allow to keep all the Switchboard-related components in the subprocess only.