### PR TITLE
SlingshotView: remove check for search length on end key

### DIFF
--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -331,10 +331,6 @@ public class Slingshot.SlingshotView : Gtk.Grid {
                 }
                 return Gdk.EVENT_PROPAGATE;
             case "End":
-                if (search_entry.text.length > 0) {
-                    return Gdk.EVENT_PROPAGATE;
-                }
-
                 if (modality == Modality.NORMAL_VIEW) {
                     grid_view.go_to_last ();
                 }


### PR DESCRIPTION
This doesn't make sense because we already propagate this keypress if the view isn't grid view. If the search entry has any text in it, it is always the search view