### PR TITLE
SlingshotView: Don't pass mod keys to search

### DIFF
--- a/data/applications-menu.appdata.xml.in
+++ b/data/applications-menu.appdata.xml.in
@@ -9,6 +9,7 @@
     <release version="2.6.1" date="2020-04-16" urgency="medium">
       <description>
         <p>Focus search when navigating up from the category view</p>
+        <p>Don't focus search when pressing modifier keys</p>
         <p>Updated translations</p>
       </description>
     </release>

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -338,7 +338,7 @@ public class Slingshot.SlingshotView : Gtk.Grid {
 
                 return Gdk.EVENT_PROPAGATE;
             default:
-                if (!search_entry.has_focus) {
+                if (!search_entry.has_focus && event.is_modifier != 1) {
                     search_entry.grab_focus ();
                     search_entry.move_cursor (Gtk.MovementStep.BUFFER_ENDS, 0, false);
                     search_entry.key_press_event (event);


### PR DESCRIPTION
Fixes an issue where pressing modifier keys (like shift) automatically throws focus to the searchbar which makes it impossible to use shortcuts like shift + → to switch pages in grid view