### PR TITLE
meson: clean up superfluous unity dep and make zeitgeist dep really optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,19 +43,11 @@ libsoup_dep = dependency('libsoup-2.4')
 appstream_dep = dependency('appstream')
 gio_unix_dep = dependency('gio-unix-2.0')
 json_glib_dep = dependency('json-glib-1.0')
-zeitgeist_dep = dependency('zeitgeist-2.0')
 switchboard_dep = dependency('switchboard-2.0')
 libgnome_menu_dep = dependency('libgnome-menu-3.0')
 libhandy_dep = dependency('libhandy-0.0')
 wingpanel_dep = dependency('wingpanel-2.0', version: '>=2.1.0')
 posix_dep = meson.get_compiler('vala').find_library('posix')
-
-unity_dep = []
-
-if get_option('with-unity')
-    unity_dep = dependency('unity', version: '>=4.0.0')
-    add_project_arguments('--define=HAVE_UNITY', language: 'vala')
-endif
 
 plank_dep = dependency('plank', required: false)
 if plank_dep.version().version_compare('>=0.10.9')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,1 @@
-option('with-unity', type : 'boolean', value : 'true', description : 'Add Unity launcher support')
 option('with-zeitgeist', type : 'boolean', value : 'true', description : 'Add Zeitgeist support')

--- a/src/meson.build
+++ b/src/meson.build
@@ -78,7 +78,6 @@ dependencies = [
     libsoup_dep,
     appstream_dep,
     plank_dep,
-    unity_dep,
     wingpanel_dep,
     libhandy_dep,
     posix_dep,


### PR DESCRIPTION
Usage of `libunity` seems to have been dropped from slingshot at some point, but the build system scaffolding for it is still there. I found no usage of `HAVE_UNITY` in the project's vala files.

- remove the `with-unity` meson option
- remove the optional `unity` dependency from meson.build files

Additionally, clean up the redundant check for `zeitgeist`, which makes it not really optional at all (since it's checked once outside the optional block, and once inside the `with-zeitgeist` option).

Fixes: #384

So: Looks like #251 has already been fixed (but not closed yet) and this PR just serves as a small cleanup afterwards :)