### PR TITLE
Revert dropping math lib; caused truncation in division

### DIFF
--- a/src/synapse-plugins/calculator-plugin.vala
+++ b/src/synapse-plugins/calculator-plugin.vala
@@ -87,7 +87,7 @@ namespace Synapse {
             if (matched) {
                 Pid pid;
                 int read_fd, write_fd;
-                string[] argv = {"bc"};
+                string[] argv = {"bc", "-l"};
                 string? solution = null;
 
                 try {

--- a/src/synapse-plugins/calculator-plugin.vala
+++ b/src/synapse-plugins/calculator-plugin.vala
@@ -87,6 +87,7 @@ namespace Synapse {
             if (matched) {
                 Pid pid;
                 int read_fd, write_fd;
+                /* Must include math library to get non-integer results and to access standard math functions */
                 string[] argv = {"bc", "-l"};
                 string? solution = null;
 


### PR DESCRIPTION
Fixes #414 

It seems unnecessary to drop the mathlib parameter and it caused the linked issue.