### PR TITLE
GridView.vala: Use non-clashing function name

### DIFF
--- a/src/Views/GridView.vala
+++ b/src/Views/GridView.vala
@@ -114,7 +114,7 @@ public class Slingshot.Widgets.Grid : Gtk.Grid {
                 current_grid.attach (new Gtk.Grid (), column, row, 1, 1);
     }
 
-    private Gtk.Widget? get_child_at (int column, int row) {
+    private Gtk.Widget? get_widget_at (int column, int row) {
         var col = ((int)(column / page.columns)) + 1;
 
         var grid = grids.get (col);
@@ -162,7 +162,7 @@ public class Slingshot.Widgets.Grid : Gtk.Grid {
     }
 
     private bool set_focus (int column, int row) {
-        var target_widget = get_child_at (column, row);
+        var target_widget = get_widget_at (column, row);
 
         if (target_widget != null) {
             go_to_number (((int) (column / page.columns)) + 1);


### PR DESCRIPTION
Fixes a compile warning.

No particular reason to use same function name as parent.