### PR TITLE
Use icon-dropshadow CSS Class on App Icons

### DIFF
--- a/src/Widgets/AppButton.vala
+++ b/src/Widgets/AppButton.vala
@@ -65,6 +65,7 @@ public class Slingshot.Widgets.AppButton : Gtk.Button {
         image.margin_top = 9;
         image.margin_end = 6;
         image.margin_start = 6;
+        image.get_style_context ().add_class ("icon-dropshadow");
 
         badge = new Gtk.Label ("!");
         badge.visible = false;

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -41,6 +41,7 @@ public class AppListRow : Gtk.ListBoxRow {
         var image = new Gtk.Image ();
         image.gicon = icon;
         image.pixel_size = 32;
+        image.get_style_context ().add_class ("icon-dropshadow");
 
         var name_label = new Gtk.Label (app_info.get_display_name ());
         name_label.set_ellipsize (Pango.EllipsizeMode.END);


### PR DESCRIPTION
Uses the `icon-dropshadow` class from https://github.com/elementary/stylesheet/pull/928 so merge that first.

Looks like this in action:
![a](https://user-images.githubusercontent.com/4886639/104465681-11ac7380-5593-11eb-948c-0561f2152420.png)

P.S. Some icons have double shadows due to the baked-in manually added shadow.