### PR TITLE
AppContextMenu: Always add AppCenter items

### DIFF
--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -25,6 +25,9 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
     private bool has_system_item = false;
     private string appstream_comp_id = "";
 
+    private Gtk.MenuItem uninstall_menuitem;
+    private Gtk.MenuItem appcenter_menuitem;
+
 #if HAS_PLANK
     private static Plank.DBusClient plank_client;
     private bool docked = false;
@@ -86,10 +89,28 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             add (plank_menuitem );
         }
 #endif
+        if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
+            if (!has_system_item && get_children ().length () > 0) {
+                add (new Gtk.SeparatorMenuItem ());
+            }
 
-        var appcenter = Backend.AppCenter.get_default ();
-        appcenter.notify["dbus"].connect (() => on_appcenter_dbus_changed.begin (appcenter));
-        on_appcenter_dbus_changed.begin (appcenter);
+            uninstall_menuitem = new Gtk.MenuItem.with_label (_("Uninstall")) {
+                sensitive = false
+            };
+            uninstall_menuitem.activate.connect (uninstall_menuitem_activate);
+
+            appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in AppCenter")) {
+                sensitive = false
+            };
+            appcenter_menuitem.activate.connect (open_in_appcenter);
+
+            add (uninstall_menuitem);
+            add (appcenter_menuitem);
+
+            var appcenter = Backend.AppCenter.get_default ();
+            appcenter.notify["dbus"].connect (() => on_appcenter_dbus_changed.begin (appcenter));
+            on_appcenter_dbus_changed.begin (appcenter);
+        }
 
         show_all ();
     }
@@ -135,28 +156,16 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         if (appcenter.dbus != null) {
             try {
                 appstream_comp_id = yield appcenter.dbus.get_component_from_desktop_id (desktop_id);
-                if (appstream_comp_id != "") {
-                    if (!has_system_item && get_children ().length () > 0) {
-                        add (new Gtk.SeparatorMenuItem ());
-                    }
-
-                    var uninstall_menuitem = new Gtk.MenuItem.with_label (_("Uninstall"));
-                    uninstall_menuitem.activate.connect (uninstall_menuitem_activate);
-
-                    var appcenter_menuitem = new Gtk.MenuItem.with_label (_("View in AppCenter"));
-                    appcenter_menuitem.activate.connect (open_in_appcenter);
-
-                    add (uninstall_menuitem);
-                    add (appcenter_menuitem);
-
-                    show_all ();
-                }
             } catch (GLib.Error e) {
+                appstream_comp_id = "";
                 warning (e.message);
             }
         } else {
             appstream_comp_id = "";
         }
+
+        uninstall_menuitem.sensitive = appstream_comp_id != "";
+        appcenter_menuitem.sensitive = appstream_comp_id != "";
     }
 
 #if HAS_PLANK


### PR DESCRIPTION
Fixes #423 

Instead of waiting to pack these menuitems until after dbus connects, we always pack them if AppCenter is installed and set sensitivity when dbus connects