### PR TITLE
Use gsettings to hide terminal applications.

### DIFF
--- a/data/io.elementary.desktop.wingpanel.applications-menu.gschema.xml
+++ b/data/io.elementary.desktop.wingpanel.applications-menu.gschema.xml
@@ -5,5 +5,10 @@
             <summary>Show the category view by default</summary>
             <description>Save the current view of the launcher.</description>
         </key>
+        <key name="hide-terminal-apps" type="b">
+            <default>true</default>
+            <summary>Hide terminal applications</summary>
+            <description>Do not show applications whose .desktop file contains 'Terminal=true'.</description>
+        </key>
 	</schema>
 </schemalist>


### PR DESCRIPTION
#426 'Hide terminal applications' is a bit rough. Many distributions like Kalilinux and ParrotOS use a lot of .desktop with 'terminal=true' in a legitimate way. With #426 this kind of distribution will never be able to use pantheon. 
So I propose to add the 'hide-terminal-apps' key to hide these applications by default. But let other distributions and advanced users the possibility to display them.