### PR TITLE
SearchView: Remove redundant header margin

### DIFF
--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -162,7 +162,6 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
         }
 
         var header = new Granite.HeaderLabel (row.result_type.to_string ());
-        header.margin_start = 6;
 
         row.set_header (header);
     }


### PR DESCRIPTION
This is now handled in the stylesheet