### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,15 @@ if get_option('with-zeitgeist')
     add_project_arguments('--define=HAVE_ZEITGEIST', language: 'vala')
 endif
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 subdir('src')
 subdir('data')
 subdir('po')

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -47,6 +47,9 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
     }
 
     construct {
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/io/elementary/desktop/wingpanel/applications-menu/icons");
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -93,6 +93,7 @@ c_args = [
 shared_module(
     meson.project_name(),
     sources,
+    config_file,
     dependencies: dependencies,
     c_args : c_args,
     install: true,
@@ -102,6 +103,7 @@ shared_module(
 executable(
     'switchboard-plugin',
     'synapse-plugins/switchboard-plugin/plugin.vala',
+    config_file,
     dependencies: [
         glib_dep,
         gobject_dep,

--- a/src/synapse-plugins/switchboard-plugin/plugin.vala
+++ b/src/synapse-plugins/switchboard-plugin/plugin.vala
@@ -17,9 +17,6 @@
 * Boston, MA 02110-1301 USA
 */
 
-[CCode (cname = "GETTEXT_PACKAGE")]
-private extern const string GETTEXT_PACKAGE;
-
 private static string? dbus_address = null;
 private const GLib.OptionEntry[] OPTIONS = {
     { "dbus-address", 0, 0, OptionArg.STRING, ref dbus_address, "D-Bus server address", "ADDRESS" },
@@ -121,6 +118,8 @@ public class SwitchboardPlugin : GLib.Object {
 public static int main (string[] args) {
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.textdomain (GETTEXT_PACKAGE);
+    Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+    Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
     try {
         var opt_context = new GLib.OptionContext ("Plugin options");


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)