### PR TITLE
Release 2.8.2

### DIFF
--- a/data/applications-menu.appdata.xml.in
+++ b/data/applications-menu.appdata.xml.in
@@ -6,7 +6,7 @@
   <name>Applications Menu</name>
   <summary>Open and search for apps</summary>
   <releases>
-    <release version="2.8.2" date="2021-08-28" urgency="medium">
+    <release version="2.8.2" date="2021-08-30" urgency="medium">
       <description>
         <p>Minor updates</p>
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'slingshot',
   'vala', 'c',
-  version : '2.8.0'
+  version : '2.8.2'
 )
 
 i18n = import('i18n')


### PR DESCRIPTION
Fixes a regression caused by switching from LibGNOMEMenu that affects webapps created by Chrome and maybe some other kinds of manually created desktop files