### PR TITLE
debian: Remove unused appstream dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,6 @@ Section: x11
 Priority: optional
 Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
-               libappstream-dev,
                libgee-0.8-dev,
                libgranite-dev (>= 5.2.1),
                libgtk-3-dev (>= 3.14.0),


### PR DESCRIPTION
To go with #506