### PR TITLE
Adds app context menu to search results

### DIFF
--- a/src/Backend/App.vala
+++ b/src/Backend/App.vala
@@ -96,6 +96,7 @@ public class Slingshot.Backend.App : Object {
 
         name = match.title;
         description = match.description;
+
         if (match.match_type == Synapse.MatchType.CONTACT && match.has_thumbnail) {
             var file = File.new_for_path (match.thumbnail_path);
             icon = new FileIcon (file);
@@ -106,6 +107,21 @@ public class Slingshot.Backend.App : Object {
         weak Gtk.IconTheme theme = Gtk.IconTheme.get_default ();
         if (theme.lookup_by_gicon (icon, 64, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
             icon = new ThemedIcon ("application-default-icon");
+        }
+
+        if (match is Synapse.ApplicationMatch) {
+
+            var app_match = (Synapse.ApplicationMatch) match;
+
+            var app_info = app_match.app_info;
+
+            this.desktop_id = app_info.get_id ();
+
+            if (app_info is DesktopAppInfo) {
+                var desktop_app_info = (DesktopAppInfo) app_info;
+                this.desktop_path = desktop_app_info.get_filename ();
+                this.prefers_default_gpu = !desktop_app_info.get_boolean ("PrefersNonDefaultGPU");
+            }
         }
 
         this.match = match;

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -70,6 +70,30 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
             });
         });
 
+        list_box.button_press_event.connect ((e) => {
+
+            var row = list_box.get_row_at_y ((int)e.y);
+            var search_item = row as SearchItem;
+
+            if (e.button != Gdk.BUTTON_SECONDARY) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+
+            return search_item.create_context_menu (e);
+        });
+
+        list_box.key_press_event.connect ((e) => {
+
+            var row = list_box.get_selected_row ();
+            var search_item = row as SearchItem;
+
+            if (e.keyval == Gdk.Key.Menu) {
+                return search_item.create_context_menu (e);
+            }
+
+            return Gdk.EVENT_PROPAGATE;
+        });
+
         add (list_box);
     }
 

--- a/src/Widgets/SearchItem.vala
+++ b/src/Widgets/SearchItem.vala
@@ -68,6 +68,8 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
     public Gtk.Image icon { public get; private set; }
     public string? app_uri { get; private set; }
 
+    private Slingshot.AppContextMenu menu;
+
     private Gtk.Label name_label;
     private Cancellable? cancellable = null;
 
@@ -180,5 +182,28 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
         base.destroy ();
         if (cancellable != null)
             cancellable.cancel ();
+    }
+    
+    public bool create_context_menu (Gdk.Event e) {
+
+        if (result_type != APPLICATION) {
+            return Gdk.EVENT_PROPAGATE;
+        }
+
+        menu = new Slingshot.AppContextMenu (app.desktop_id, app.desktop_path);
+
+        menu.app_launched.connect (() => launch_app());
+
+        if (menu.get_children () != null) {
+            if (e.type == Gdk.EventType.KEY_PRESS) {
+                menu.popup_at_widget (this, Gdk.Gravity.EAST, Gdk.Gravity.CENTER, e);
+                return Gdk.EVENT_STOP;
+            } else if (e.type == Gdk.EventType.BUTTON_PRESS) {
+                menu.popup_at_pointer (e);
+                return Gdk.EVENT_STOP;
+            }
+        }
+
+        return Gdk.EVENT_PROPAGATE;
     }
 }

--- a/src/synapse-plugins/desktop-file-plugin.vala
+++ b/src/synapse-plugins/desktop-file-plugin.vala
@@ -105,6 +105,7 @@ namespace Synapse {
                 this.desktop_id = "application://" + info.desktop_id;
                 this.generic_name = info.generic_name;
                 this.gettext_domain = info.gettext_domain;
+                this.app_info = new GLib.DesktopAppInfo (info.desktop_id);
             }
         }
 


### PR DESCRIPTION
This pull request enables the same AppContextMenu that appears in the normal view to also appear for Application results in the search view.

This allows you to search for an application, and perform the various actions on it (such as using the Hybrid Graphics options)