### PR TITLE
CategoryView: Remove no longer used dgettext

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y libappstream-dev libgee-0.8-dev libgnome-menu-3-dev libgranite-dev libgtk-3-dev libhandy-1-dev libjson-glib-dev libplank-dev libsoup2.4-dev libswitchboard-2.0-dev libunity-dev libwingpanel-dev libzeitgeist-2.0-dev meson valac bc
+        apt install -y libgee-0.8-dev libgranite-dev libgtk-3-dev libhandy-1-dev libjson-glib-dev libplank-dev libsoup2.4-dev libswitchboard-2.0-dev libunity-dev libwingpanel-dev libzeitgeist-2.0-dev meson valac bc
     - name: Build
       env:
         DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Lightweight and stylish app launcher.
 ## Building and Installation
 
 You'll need the following dependencies:
+* bc
 * libgee-0.8-dev
 * libgranite-dev >= 6.1.0
 * libgtk-3-dev

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -151,7 +151,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
     }
 
     private static int category_sort_func (CategoryRow row1, CategoryRow row2) {
-        return row1.translated_name.collate (row2.translated_name);
+        return row1.cat_name.collate (row2.cat_name);
     }
 
     private bool create_context_menu (Gdk.Event event) {
@@ -278,18 +278,13 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
     private class CategoryRow : Gtk.ListBoxRow {
         public string cat_name { get; construct; }
-        public string translated_name {
-            get {
-                return GLib.dgettext ("gnome-menus-3.0", cat_name);
-            }
-        }
 
         public CategoryRow (string cat_name) {
             Object (cat_name: cat_name);
         }
 
         construct {
-            var label = new Gtk.Label (translated_name);
+            var label = new Gtk.Label (cat_name);
             label.halign = Gtk.Align.START;
             label.margin_start = 3;
 


### PR DESCRIPTION
We no longer use gnome-menus (#496) and removed it from deb-packaging too (706d383a910670c71248c19562a983b38f70398f) so `dgettext ("gnome-menus-3.0", cat_name)` does nothing here.

Confirmed this change does not affect to the localized category text:

![VirtualBox_elementary OS 7 1_14_10_2023_16_07_01](https://github.com/elementary/applications-menu/assets/26003928/8495f623-33f2-4ed0-8c56-1aee859aa6fc)

Also reviewed dependencies list in GitHub Actions and README while I'm here.