### PR TITLE
Consistency improvement with dock menu item

### DIFF
--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -98,7 +98,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                 label = _("Add to _Dock"),
                 use_underline = true
             };
-            
+
             // Try to get docked state
             try {
                 dock_menuitem.active = desktop_id in dock.dbus.list_launchers ();

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -83,7 +83,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         if (Environment.find_program_in_path ("io.elementary.dock") != null) {
             if (get_children ().length () > 0) {
                 add (new Gtk.SeparatorMenuItem ());
-            };
+            }
 
             has_system_item = true;
 

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -43,7 +43,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         switcheroo_control = new Slingshot.Backend.SwitcherooControl ();
         app_info = new DesktopAppInfo (desktop_id);
 
-        // Quick app actions
         foreach (unowned string _action in app_info.list_actions ()) {
             string action = _action.dup ();
             var menuitem = new Gtk.MenuItem.with_mnemonic (app_info.get_action_name (action));
@@ -81,7 +80,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             });
         }
 
-        // "Add To Dock" item. We check first whether dock is there
         if (Environment.find_program_in_path ("io.elementary.dock") != null) {
             if (get_children ().length () > 0) {
                 add (new Gtk.SeparatorMenuItem ());
@@ -104,10 +102,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                     critical (e.message);
                 }
 
-                // Connect and display
                 dock_menuitem.activate.connect (dock_menuitem_activate);
 
-                // Listen to changes
                 dock.notify["dbus"].connect (() => on_dock_dbus_changed (dock));
                 on_dock_dbus_changed (dock);
             }
@@ -116,7 +112,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
         }
 
-        // App management capabilities
         if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
             if (!has_system_item && get_children ().length () > 0) {
                 add (new Gtk.SeparatorMenuItem ());

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -39,8 +39,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
     }
 
     construct {
-
         switcheroo_control = new Slingshot.Backend.SwitcherooControl ();
+
         app_info = new DesktopAppInfo (desktop_id);
 
         foreach (unowned string _action in app_info.list_actions ()) {
@@ -83,7 +83,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         if (Environment.find_program_in_path ("io.elementary.dock") != null) {
             if (get_children ().length () > 0) {
                 add (new Gtk.SeparatorMenuItem ());
-            }
+            };
+
             has_system_item = true;
 
             dock_menuitem = new Gtk.CheckMenuItem () {

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -207,6 +207,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         if (dock.dbus == null) {
             return;
         }
+
         try {
             if (dock_menuitem.active) {
                 dock.dbus.add_launcher (desktop_id);

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -103,7 +103,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             on_dock_dbus_changed (dock);
         }
 
-
         if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
             if (!has_system_item && get_children ().length () > 0) {
                 add (new Gtk.SeparatorMenuItem ());

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -87,31 +87,22 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
             has_system_item = true;
 
+            var dock = Backend.Dock.get_default ();
+
             dock_menuitem = new Gtk.CheckMenuItem () {
                 label = _("Add to _Dock"),
                 use_underline = true,
                 sensitive = false
             };
 
-            var dock = Backend.Dock.get_default ();
-            if (dock.dbus != null) {
-                dock_menuitem.sensitive = true;
-
-                try {
-                    dock_menuitem.active = desktop_id in dock.dbus.list_launchers ();
-                } catch (GLib.Error e) {
-                    critical (e.message);
-                }
-
-                dock_menuitem.activate.connect (dock_menuitem_activate);
-
-                dock.notify["dbus"].connect (() => on_dock_dbus_changed (dock));
-                on_dock_dbus_changed (dock);
-            }
+            dock_menuitem.activate.connect (dock_menuitem_activate);
 
             add (dock_menuitem);
 
+            dock.notify["dbus"].connect (() => on_dock_dbus_changed (dock));
+            on_dock_dbus_changed (dock);
         }
+
 
         if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
             if (!has_system_item && get_children ().length () > 0) {
@@ -194,11 +185,15 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
     private void on_dock_dbus_changed (Backend.Dock dock) {
         if (dock.dbus != null) {
+            dock_menuitem.sensitive = true;
+
             try {
                 dock_menuitem.active = desktop_id in dock.dbus.list_launchers ();
             } catch (GLib.Error e) {
                 critical (e.message);
             }
+        } else {
+            dock_menuitem.sensitive = false;
         }
     }
 

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -38,10 +38,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         );
     }
 
-    // Context menu construction
     construct {
 
-        // GPU Switching capabilities ("Switcheroo")
         switcheroo_control = new Slingshot.Backend.SwitcherooControl ();
         app_info = new DesktopAppInfo (desktop_id);
 
@@ -59,7 +57,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             });
         }
 
-        // GPU Switching capabilities ("Switcheroo")
         if (switcheroo_control != null && switcheroo_control.has_dual_gpu) {
             bool prefers_non_default_gpu = app_info.get_boolean ("PrefersNonDefaultGPU");
 
@@ -91,19 +88,16 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             }
             has_system_item = true;
 
-            // Create menu item
             dock_menuitem = new Gtk.CheckMenuItem () {
                 label = _("Add to _Dock"),
                 use_underline = true,
                 sensitive = false
             };
 
-            // Dock is enabled on dbus
             var dock = Backend.Dock.get_default ();
             if (dock.dbus != null) {
                 dock_menuitem.sensitive = true;
 
-                // Try to get docked state
                 try {
                     dock_menuitem.active = desktop_id in dock.dbus.list_launchers ();
                 } catch (GLib.Error e) {
@@ -122,7 +116,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
 
         }
 
-        // App management capabilities. Depends on 
+        // App management capabilities
         if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
             if (!has_system_item && get_children ().length () > 0) {
                 add (new Gtk.SeparatorMenuItem ());
@@ -149,7 +143,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         show_all ();
     }
 
-    // When user clicks on Uninstall
     private void uninstall_menuitem_activate () {
         var appcenter = Backend.AppCenter.get_default ();
         if (appcenter.dbus == null || appstream_comp_id == "") {
@@ -167,7 +160,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         });
     }
 
-    // When user clicks on "Open in appcenter"
     private void open_in_appcenter () {
         AppInfo.launch_default_for_uri_async.begin ("appstream://" + appstream_comp_id, null, null, (obj, res) => {
             try {
@@ -188,7 +180,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         });
     }
 
-    // React to changes in app status
     private async void on_appcenter_dbus_changed (Backend.AppCenter appcenter) {
         if (appcenter.dbus != null) {
             try {
@@ -205,7 +196,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         appcenter_menuitem.sensitive = appstream_comp_id != "";
     }
 
-    // React to changes in pinned dock list to keep the item in sync
     private void on_dock_dbus_changed (Backend.Dock dock) {
         if (dock.dbus != null) {
             try {
@@ -216,7 +206,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         }
     }
 
-    // When user clicks on "Add to Dock" (Checked or not)
     private void dock_menuitem_activate () {
         var dock = Backend.Dock.get_default ();
         if (dock.dbus == null) {
@@ -225,7 +214,6 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         try {
             if (dock_menuitem.active) {
                 dock.dbus.add_launcher (desktop_id);
-
             } else {
                 dock.dbus.remove_launcher (desktop_id);
             }


### PR DESCRIPTION
Fixes https://github.com/elementary/applications-menu/issues/620
Fixes https://github.com/elementary/applications-menu/issues/621

Ive tested both changing state in the dock and appmenu, for several apps, several times - it works.

Second commit removes usage of the "docked" variable, state would be tracked by the checkmenuitem state - more variables to keep in sync means more variables to keep track of and more opportunities for bugs down the line.
If you prefer keeping it, first commit works on its own.

i hope there arent too much new comments ? Needed to understand how its done and navigate. It may make the file new friendly for new contributors, but should have been its own separate commit.
