### PR TITLE
Add Recent/Pinned category

### DIFF
--- a/src/Backend/App.vala
+++ b/src/Backend/App.vala
@@ -34,7 +34,7 @@ public class Slingshot.Backend.App : Object {
     public string exec { get; private set; }
     public string[] keywords { get; private set;}
     public Icon icon { get; private set; default = new ThemedIcon ("application-default-icon"); }
-    public double popularity { get; set; }
+    public int popularity { get; set; }
     public string desktop_path { get; private set; }
     public string categories { get; private set; }
     public string generic_name { get; private set; default = ""; }

--- a/src/Backend/AppSystem.vala
+++ b/src/Backend/AppSystem.vala
@@ -220,4 +220,30 @@ public class Slingshot.Backend.AppSystem : Object {
     private static int sort_apps_by_name (Backend.App a, Backend.App b) {
         return a.name.collate (b.name);
     }
+
+#if HAVE_ZEITGEIST
+    public SList<App> get_apps_by_popularity () {
+        var sorted_apps = new SList<App> ();
+        string[] sorted_apps_execs = {};
+
+        foreach (Gee.ArrayList<App> category in apps.values) {
+            foreach (App app in category) {
+                if (!(app.exec in sorted_apps_execs)) {
+                    sorted_apps.insert_sorted_with_data (app, sort_apps_by_popularity);
+                    sorted_apps_execs += app.exec;
+                }
+            }
+        }
+
+        return sorted_apps;
+    }
+
+    private static int sort_apps_by_popularity (Backend.App a, Backend.App b) {
+        if (a.popularity == b.popularity) {
+            return a.name.collate (b.name);
+        }
+
+        return a.popularity > b.popularity ? 1 : -1;
+    }
+#endif
 }

--- a/src/Backend/AppSystem.vala
+++ b/src/Backend/AppSystem.vala
@@ -63,11 +63,17 @@ public class Slingshot.Backend.AppSystem : Object {
     private void update_app_system () {
         debug ("Updating Applications menu tree…");
 #if HAVE_ZEITGEIST
-        rl_service.refresh_popularity ();
+        rl_service.refresh_popularity.begin ();
 #endif
 
         update_categories_index ();
         changed ();
+    }
+
+    public async void update_popularities () {
+#if HAVE_ZEITGEIST
+        yield rl_service.refresh_popularity ();
+#endif
     }
 
     private void update_categories_index () {

--- a/src/Backend/RelevancyService.vala
+++ b/src/Backend/RelevancyService.vala
@@ -26,8 +26,6 @@ public class Slingshot.Backend.RelevancyService : Object {
     private bool has_datahub_gio_module = false;
     private bool refreshing = false;
 
-    private const float MULTIPLIER = 65535.0f;
-
     public signal void update_complete ();
 
     public RelevancyService () {
@@ -104,7 +102,6 @@ public class Slingshot.Backend.RelevancyService : Object {
 
         var ptr_arr = new GLib.GenericArray<Zeitgeist.Event> ();
         ptr_arr.add (event);
-
         try {
             Zeitgeist.ResultSet rs = yield zg_log.find_events (tr, ptr_arr,
                     Zeitgeist.StorageState.ANY,
@@ -119,13 +116,15 @@ public class Slingshot.Backend.RelevancyService : Object {
             // Zeitgeist (0.6) doesn't have any stats API, so let's approximate
 
             foreach (Zeitgeist.Event e in rs) {
+                if (e.num_subjects () <= 0) {
+                    continue;
+                }
 
-                if (e.num_subjects () <= 0) continue;
                 Zeitgeist.Subject s = e.get_subject (0);
 
-                float power = index / (size * 2) + 0.5f; // linearly <0.5, 1.0>
-                float relevancy = 1.0f / Math.powf (index + 1, power);
-                app_popularity[s.uri] = (int)(relevancy * MULTIPLIER);
+                // Simply use the (inverted) order of the app in the result set as 
+                // measure of popularity for now.  Suffices for the applications menu.
+                app_popularity[s.uri] = (int) (size - index);
                 index++;
             }
             update_complete ();
@@ -137,15 +136,15 @@ public class Slingshot.Backend.RelevancyService : Object {
         }
     }
 
-    public float get_app_popularity (string desktop_id) {
-
+    public int get_app_popularity (string desktop_id) {
         var id = "application://" + desktop_id;
 
         if (app_popularity.has_key (id)) {
-            return app_popularity[id] / MULTIPLIER;
+            // return app_popularity[id] / MULTIPLIER;
+            return app_popularity[id];
         }
 
-        return 0.0f;
+        return 0;
     }
 
     public void app_launched (App app) {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -60,33 +60,6 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
     }
 
     public override Gtk.Widget? get_widget () {
-        if (view == null) {
-            view = new SlingshotView ();
-
-            unowned var unity_client = Unity.get_default ();
-            unity_client.add_client (view);
-
-            view.close_indicator.connect (on_close_indicator);
-
-            if (dbus_service == null) {
-                dbus_service = new DBusService (view);
-            }
-
-            if (dock_settings != null) {
-                dock_settings.changed.connect ((key) => {
-                    if (key == "launchers") {
-                        view.update (dock_settings.get_strv ("launchers"));
-                    }
-                });
-            }
-        }
-
-        // Wait for AppSystem to initialize
-        Idle.add (() => {
-            view.update (dock_settings != null ? dock_settings.get_strv ("launchers") : null);
-            return Source.REMOVE;
-        });
-
         return view;
     }
 
@@ -120,6 +93,35 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
         }
 
         visible = true;
+
+        // Create the view now so that there is time for app popularities to initialise
+        // before the view is shown for the first time.
+        if (view == null) {
+            view = new SlingshotView ();
+
+            unowned var unity_client = Unity.get_default ();
+            unity_client.add_client (view);
+
+            view.close_indicator.connect (on_close_indicator);
+
+            if (dbus_service == null) {
+                dbus_service = new DBusService (view);
+            }
+
+            if (dock_settings != null) {
+                dock_settings.changed.connect ((key) => {
+                    if (key == "launchers") {
+                        view.update (dock_settings.get_strv ("launchers"));
+                    }
+                });
+            }
+        }
+
+        // Wait for AppSystem to initialize
+        Idle.add (() => {
+            view.update (dock_settings != null ? dock_settings.get_strv ("launchers") : null);
+            return Source.REMOVE;
+        });
 
         return indicator_grid;
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -71,6 +71,15 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
             if (dbus_service == null) {
                 dbus_service = new DBusService (view);
             }
+
+            if (dock_settings != null) {
+                dock_settings.changed.connect ((key) => {
+                    if (key == "launchers") {
+                        view.update_favorites (dock_settings.get_strv ("launchers"));
+                    }
+                });
+                view.update_favorites (dock_settings.get_strv ("launchers"));
+            }
         }
 
         return view;
@@ -102,15 +111,6 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
                         update_tooltip ();
                     }
                 });
-            }
-
-            if (dock_settings != null) {
-                dock_settings.changed.connect ((key) => {
-                    if (key == "launchers") {
-                        update_favorites (dock_settings.get_strv ("launchers"));
-                    }
-                });
-                update_favorites (dock_settings.get_strv ("launchers"));
             }
         }
 
@@ -145,12 +145,6 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
         }
 
         indicator_grid.tooltip_markup = Granite.markup_accel_tooltip (accels, _("Open and search apps"));
-    }
-
-    private void update_favorites (string[] dock_launchers) {
-       if (view != null) {
-           view.update_favorites (dock_launchers);
-       }
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -19,6 +19,7 @@
 public class Slingshot.Indicator : Wingpanel.Indicator {
     private const string KEYBINDING_SCHEMA = "io.elementary.desktop.wm.keybindings";
     private const string GALA_BEHAVIOR_SCHEMA = "io.elementary.desktop.wm.behavior";
+    private const string DOCK_SCHEMA = "io.elementary.dock";
 
     private DBusService? dbus_service = null;
     private Gtk.Grid? indicator_grid = null;
@@ -26,6 +27,7 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
 
     private static GLib.Settings? keybinding_settings;
     private static GLib.Settings? gala_behavior_settings;
+    private static GLib.Settings? dock_settings;
 
     public Indicator () {
         Object (code_name: Wingpanel.Indicator.APP_LAUNCHER);
@@ -38,6 +40,10 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
 
         if (SettingsSchemaSource.get_default ().lookup (GALA_BEHAVIOR_SCHEMA, true) != null) {
             gala_behavior_settings = new GLib.Settings (GALA_BEHAVIOR_SCHEMA);
+        }
+
+        if (SettingsSchemaSource.get_default ().lookup (DOCK_SCHEMA, true) != null) {
+            dock_settings = new GLib.Settings (DOCK_SCHEMA);
         }
     }
 
@@ -97,6 +103,15 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
                     }
                 });
             }
+
+            if (dock_settings != null) {
+                dock_settings.changed.connect ((key) => {
+                    if (key == "launchers") {
+                        update_favorites (dock_settings.get_strv ("launchers"));
+                    }
+                });
+                update_favorites (dock_settings.get_strv ("launchers"));
+            }
         }
 
         visible = true;
@@ -130,6 +145,12 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
         }
 
         indicator_grid.tooltip_markup = Granite.markup_accel_tooltip (accels, _("Open and search apps"));
+    }
+
+    private void update_favorites (string[] dock_launchers) {
+       if (view != null) {
+           view.update_favorites (dock_launchers);
+       }
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -75,12 +75,17 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
             if (dock_settings != null) {
                 dock_settings.changed.connect ((key) => {
                     if (key == "launchers") {
-                        view.update_pinned (dock_settings.get_strv ("launchers"));
+                        view.update (dock_settings.get_strv ("launchers"));
                     }
                 });
-                view.update_pinned (dock_settings.get_strv ("launchers"));
             }
         }
+
+        // Wait for AppSystem to initialize
+        Idle.add (() => {
+            view.update (dock_settings != null ? dock_settings.get_strv ("launchers") : null);
+            return Source.REMOVE;
+        });
 
         return view;
     }
@@ -120,8 +125,9 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
     }
 
     public override void opened () {
-        if (view != null)
+        if (view != null) {
             view.show_slingshot ();
+        }
     }
 
     public override void closed () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -75,10 +75,10 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
             if (dock_settings != null) {
                 dock_settings.changed.connect ((key) => {
                     if (key == "launchers") {
-                        view.update_favorites (dock_settings.get_strv ("launchers"));
+                        view.update_pinned (dock_settings.get_strv ("launchers"));
                     }
                 });
-                view.update_favorites (dock_settings.get_strv ("launchers"));
+                view.update_pinned (dock_settings.get_strv ("launchers"));
             }
         }
 

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -159,13 +159,12 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
         // Auto-update applications grid
         app_system.changed.connect (() => {
             grid_view.populate (app_system);
-
-            category_view.setup_sidebar ();
+            category_view.update (null);
         });
     }
 
-    public void update_pinned (string[] pinned) {
-        category_view.update_pinned (pinned);
+    public void update (string[] pinned) {
+        category_view.update (pinned);
     }
 
     public void update_launcher_entry (string sender_name, GLib.Variant parameters, bool is_retry = false) {
@@ -327,6 +326,7 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
 
     public void show_slingshot () {
         search_entry.text = "";
+        category_view.update (null);
 
     /* TODO
         set_focus (null);

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -164,8 +164,8 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
         });
     }
 
-    public void update_favorites (string[] favs) {
-        category_view.update_favorites (favs);
+    public void update_pinned (string[] pinned) {
+        category_view.update_pinned (pinned);
     }
 
     public void update_launcher_entry (string sender_name, GLib.Variant parameters, bool is_retry = false) {

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -164,6 +164,10 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
         });
     }
 
+    public void update_favorites (string[] favs) {
+        category_view.update_favorites (favs);
+    }
+
     public void update_launcher_entry (string sender_name, GLib.Variant parameters, bool is_retry = false) {
         if (!is_retry) {
             // Wait to let further update requests come in to catch the case where one application

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -19,6 +19,7 @@
 public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
     public signal void search_focus_request ();
 
+    public const string FAVORITE_CATEGORY = N_("Favorites");
     public SlingshotView view { get; construct; }
 
     private bool dragging = false;
@@ -208,23 +209,18 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
             listbox.add (new AppListRow (app.desktop_id, app.desktop_path));
         }
 
+        listbox.show_all ();
 
         // Fill the sidebar
         unowned Gtk.ListBoxRow? new_selected = null;
         CategoryRow row;
+        // Add Favorites category if there are any pinned apps
         int n_rows = 0;
         if (favorites.size > 0) {
-            // Add Favorite category
-            row = new CategoryRow (_("Favorites"));
+            row = new CategoryRow (_(FAVORITE_CATEGORY));
             category_switcher.add (row);
             n_rows++;
-
-            foreach (string app_id in favorites) {
-                listbox.add (new AppListRow (app_id, ""));
-            }
         }
-
-        listbox.show_all ();
 
         foreach (string cat_name in view.app_system.apps.keys) {
             if (cat_name == "switchboard") {
@@ -235,7 +231,6 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
             category_switcher.add (row);
             n_rows++;
         }
-
 
         if (old_selected != null) {
             for (int i = 0; i < n_rows; i++) {
@@ -253,19 +248,19 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
     public void update_favorites (string[] favs) {
         favorites.clear ();
-        foreach (string s in favs) {
-            favorites.add (s);
+        foreach (string app_id in favs) {
+            favorites.add (app_id);
         }
 
-        listbox.invalidate_filter ();
         setup_sidebar ();
+        listbox.invalidate_filter ();
     }
 
     [CCode (instance_pos = -1)]
     private bool filter_function (AppListRow row) {
         unowned CategoryRow category_row = (CategoryRow) category_switcher.get_selected_row ();
         if (category_row != null) {
-            if (category_row.cat_name == _("Favorites")) {
+            if (category_row.cat_name == _(FAVORITE_CATEGORY)) {
                 return favorites.contains (row.app_id);
             }
 

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -208,15 +208,28 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
         // Fill the sidebar
         unowned Gtk.ListBoxRow? new_selected = null;
+        // Add Favorite category
+        var row = new CategoryRow (_("Favorites"));
+        category_switcher.add (row);
+        int n_rows = 1;
         foreach (string cat_name in view.app_system.apps.keys) {
             if (cat_name == "switchboard") {
                 continue;
             }
 
-            var row = new CategoryRow (cat_name);
+            row = new CategoryRow (cat_name);
             category_switcher.add (row);
-            if (old_selected != null && old_selected.cat_name == cat_name) {
-                new_selected = row;
+            n_rows++;
+        }
+
+
+        if (old_selected != null) {
+            for (int i = 0; i < n_rows; i++) {
+                row = (CategoryRow) category_switcher.get_row_at_index (i);
+                if (old_selected.cat_name == row.cat_name) {
+                    new_selected = row;
+                    break;
+                }
             }
         }
 

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -17,24 +17,23 @@
  * Boston, MA 02110-1301 USA.
  */
 
-public class AppListRow : Gtk.ListBoxRow {
-    public string app_id { get; construct; }
-    public string display_name { get; construct; }
-    public int popularity { get; construct; }
-    public string desktop_path { get; construct; }
-    public GLib.DesktopAppInfo app_info { get; private set; }
+public class Slingshot.AppListRow : Gtk.ListBoxRow {
+    public Backend.App app {get; construct; }
+    public string app_id { get { return app.desktop_id; }}
+    public int popularity { get { return app.popularity; }}
+    public string desktop_path { get { return app.desktop_path; }}
+    public string display_name { get; private set; }
+    public Icon icon { get { return app_info.get_icon (); }}
+    private GLib.DesktopAppInfo app_info;
 
-    public AppListRow (string app_id, string desktop_path, int popularity) {
+    public AppListRow (Backend.App app) {
         Object (
-            app_id: app_id,
-            desktop_path: desktop_path,
-            popularity: popularity
+            app: app
         );
     }
 
     construct {
         app_info = new GLib.DesktopAppInfo (app_id);
-
         var icon = app_info.get_icon ();
         weak Gtk.IconTheme theme = Gtk.IconTheme.get_default ();
         if (icon == null || theme.lookup_by_gicon (icon, 32, Gtk.IconLookupFlags.USE_BUILTIN) == null) {

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -19,13 +19,16 @@
 
 public class AppListRow : Gtk.ListBoxRow {
     public string app_id { get; construct; }
+    public string display_name { get; construct; }
+    public int popularity { get; construct; }
     public string desktop_path { get; construct; }
     public GLib.DesktopAppInfo app_info { get; private set; }
 
-    public AppListRow (string app_id, string desktop_path) {
+    public AppListRow (string app_id, string desktop_path, int popularity) {
         Object (
             app_id: app_id,
-            desktop_path: desktop_path
+            desktop_path: desktop_path,
+            popularity: popularity
         );
     }
 
@@ -42,7 +45,8 @@ public class AppListRow : Gtk.ListBoxRow {
         image.gicon = icon;
         image.pixel_size = 32;
 
-        var name_label = new Gtk.Label (app_info.get_display_name ());
+        display_name = app_info.get_display_name () + " " + popularity.to_string ();
+        var name_label = new Gtk.Label (display_name);
         name_label.set_ellipsize (Pango.EllipsizeMode.END);
         name_label.xalign = 0;
 

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -45,7 +45,7 @@ public class AppListRow : Gtk.ListBoxRow {
         image.gicon = icon;
         image.pixel_size = 32;
 
-        display_name = app_info.get_display_name () + " " + popularity.to_string ();
+        display_name = app_info.get_display_name ();
         var name_label = new Gtk.Label (display_name);
         name_label.set_ellipsize (Pango.EllipsizeMode.END);
         name_label.xalign = 0;


### PR DESCRIPTION
Fixes #535 

One of two new categories may be created, depending on the build options

If the Zeitgeist option is compiled in: 
 - Recently used apps.  Shows apps used in the last [4] weeks in descending order of usage as determined by Zeitgeist.  This uses the pre-existing (but hitherto unused) code related to app popularity but simplifies the calculation of the popularity measure.

If there is no Zeitgeist:
 - Pinned apps - this is still useful for those of us who dislike using the dock or have a window fullscreened/maximised so the dock does not appear on screen.

It would be possible to have a further build or system option to control showing of the Pinned category but that is left for now.

Unless another category has been previously selected, the Recent/Pinned category is selected by default.

TODO
 - [x] Make sure app popularities have finished initialising when first shown after restart.
 - [x] Update the Recently used category after an app has been used.  At the moment the indicator has to be restarted.