### PR TITLE
AppContextMenu: change keep in dock label

### DIFF
--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -90,7 +90,7 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
             var dock = Backend.Dock.get_default ();
 
             dock_menuitem = new Gtk.CheckMenuItem () {
-                label = _("Add to _Dock"),
+                label = _("Keep in _Dock"),
                 use_underline = true,
                 sensitive = false
             };


### PR DESCRIPTION
I don't love using a verbal phrase with a checkbox. Use the same label as we use in the Dock.