### PR TITLE
AppContextMenu: Use GLib.Action

### DIFF
--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 elementary, Inc. (https://elementary.io)
+ * Copyright 2019-2025 elementary, Inc. (https://elementary.io)
  * Copyright 2020-2021 Justin Haygood
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
Gtk.MenuItem is removed in GTK4. First step to replacing it with a menu model is to use GLib.Action for menu items