### PR TITLE
SlingshotView: use SearchEntry.handle_event

### DIFF
--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -130,11 +130,6 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
             search.begin (search_entry.text, match, target);
         });
 
-        focus_in_event.connect (() => {
-            search_entry.grab_focus ();
-            return Gdk.EVENT_PROPAGATE;
-        });
-
         key_press_event.connect (on_key_press);
         search_entry.key_press_event.connect (on_search_view_key_press);
 
@@ -146,12 +141,7 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
             search.begin (search_entry.text);
         });
 
-        search_entry.grab_focus ();
         search_entry.activate.connect (search_entry_activated);
-
-        category_view.search_focus_request.connect (() => {
-            search_entry.grab_focus ();
-        });
 
         grid_view.app_launched.connect (() => {
             close_indicator ();
@@ -278,24 +268,11 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
                         }
                     }
 
-                    // FIXME: Workaround to avoid losing focus completely
-                    search_entry.grab_focus ();
                     return Gdk.EVENT_STOP;
             }
         }
 
         switch (key) {
-            case "Down":
-            case "Enter": // "KP_Enter"
-            case "Home":
-            case "KP_Enter":
-            case "Left":
-            case "Return":
-            case "Right":
-            case "Tab":
-            case "Up":
-                return Gdk.EVENT_PROPAGATE;
-
             case "Page_Up":
                 if (modality == Modality.NORMAL_VIEW) {
                     grid_view.go_to_previous ();
@@ -312,38 +289,27 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
                 }
                 break;
 
-            case "BackSpace":
-                if (!search_entry.has_focus) {
-                    search_entry.grab_focus ();
-                    search_entry.move_cursor (Gtk.MovementStep.BUFFER_ENDS, 0, false);
-                }
-                return Gdk.EVENT_PROPAGATE;
             case "End":
                 if (modality == Modality.NORMAL_VIEW) {
                     grid_view.go_to_last ();
                 }
 
                 return Gdk.EVENT_PROPAGATE;
-            default:
-                if (!search_entry.has_focus && event.is_modifier != 1) {
-                    search_entry.grab_focus ();
-                    search_entry.move_cursor (Gtk.MovementStep.BUFFER_ENDS, 0, false);
-                    search_entry.key_press_event (event);
-                }
-                return Gdk.EVENT_PROPAGATE;
-
         }
 
-        return search_entry.handle_event (event);
+        var search_handles_event = search_entry.handle_event (event);
+        if (search_handles_event && !search_entry.has_focus) {
+            search_entry.grab_focus ();
+            search_entry.move_cursor (BUFFER_ENDS, 0, false);
+        }
+
+        return search_handles_event;
     }
 
     public void show_slingshot () {
         search_entry.text = "";
-
-    /* TODO
-        set_focus (null);
-    */
         search_entry.grab_focus ();
+
         // This is needed in order to not animate if the previous view was the search view.
         view_selector_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
         stack.transition_type = Gtk.StackTransitionType.NONE;
@@ -359,15 +325,11 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
             case Modality.NORMAL_VIEW:
                 view_selector_revealer.set_reveal_child (true);
                 stack.set_visible_child_name ("normal");
-
-                search_entry.grab_focus ();
                 break;
 
             case Modality.CATEGORY_VIEW:
                 view_selector_revealer.set_reveal_child (true);
                 stack.set_visible_child_name ("category");
-
-                search_entry.grab_focus ();
                 break;
 
             case Modality.SEARCH_VIEW:

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -112,11 +112,8 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
         // This function must be after creating the page switcher
         grid_view.populate (app_system);
 
-        var event_box = new Gtk.EventBox ();
-        event_box.add (container);
-
         // Add the container to the dialog's content area
-        this.add (event_box);
+        this.add (container);
 
         var category_action = settings.create_action ("view-mode");
 
@@ -138,7 +135,7 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
             return Gdk.EVENT_PROPAGATE;
         });
 
-        event_box.key_press_event.connect (on_event_box_key_press);
+        key_press_event.connect (on_key_press);
         search_entry.key_press_event.connect (on_search_view_key_press);
 
         // Showing a menu reverts the effect of the grab_device function.
@@ -242,7 +239,7 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
         return Gdk.EVENT_PROPAGATE;
     }
 
-    public bool on_event_box_key_press (Gdk.EventKey event) {
+    public bool on_key_press (Gdk.EventKey event) {
         var key = Gdk.keyval_name (event.keyval).replace ("KP_", "");
         if ((event.state & Gdk.ModifierType.CONTROL_MASK) != 0) {
             switch (key) {
@@ -337,7 +334,7 @@ public class Slingshot.SlingshotView : Gtk.Grid, UnityClient {
 
         }
 
-        return Gdk.EVENT_STOP;
+        return search_entry.handle_event (event);
     }
 
     public void show_slingshot () {

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -17,8 +17,6 @@
  */
 
 public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
-    public signal void search_focus_request ();
-
     public SlingshotView view { get; construct; }
 
     private bool dragging = false;
@@ -67,10 +65,6 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
         category_switcher.row_selected.connect (() => {
             listbox.invalidate_filter ();
-        });
-
-        category_switcher.search_focus_request.connect (() => {
-            search_focus_request ();
         });
 
         listbox.row_activated.connect ((row) => {
@@ -141,10 +135,6 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
             if (drag_uri != null) {
                 sel.set_uris ({drag_uri});
             }
-        });
-
-        listbox.search_focus_request.connect (() => {
-            search_focus_request ();
         });
 
         setup_sidebar ();
@@ -293,8 +283,6 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
     }
 
     private class NavListBox : Gtk.ListBox {
-        public signal void search_focus_request ();
-
         public override void move_cursor (Gtk.MovementStep step, int count) {
             unowned Gtk.ListBoxRow selected = get_selected_row ();
             if (
@@ -303,7 +291,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
                 step == DISPLAY_LINES &&
                 count == -1
             ) {
-                search_focus_request ();
+                move_focus (Gtk.DirectionType.TAB_BACKWARD);
             } else {
                 base.move_cursor (step, count);
             }


### PR DESCRIPTION
Use GTK's built-in method for determining if a key event should be handled by the search entry. Should prevent keypress stealing and unnecessary focus shifting