### PR TITLE
Move icon fallbacks to widgets

### DIFF
--- a/src/Backend/App.vala
+++ b/src/Backend/App.vala
@@ -72,11 +72,6 @@ public class Slingshot.Backend.App : Object {
         if (desktop_icon != null) {
             icon = desktop_icon;
         }
-
-        weak Gtk.IconTheme theme = Gtk.IconTheme.get_default ();
-        if (theme.lookup_by_gicon (icon, 64, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
-            icon = new ThemedIcon ("application-default-icon");
-        }
     }
 
     public App.from_command (string command) {
@@ -100,11 +95,6 @@ public class Slingshot.Backend.App : Object {
             icon = new FileIcon (file);
         } else if (match.icon_name != null) {
             icon = new ThemedIcon (match.icon_name);
-        }
-
-        weak Gtk.IconTheme theme = Gtk.IconTheme.get_default ();
-        if (theme.lookup_by_gicon (icon, 64, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
-            icon = new ThemedIcon ("application-default-icon");
         }
 
         if (match is Synapse.ApplicationMatch) {

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -120,7 +120,7 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
                 var drag_item = (Slingshot.Widgets.SearchItem) selected_row;
                 drag_uri = drag_item.app_uri;
                 if (drag_uri != null) {
-                    Gtk.drag_set_icon_gicon (ctx, drag_item.icon.gicon, 32, 32);
+                    Gtk.drag_set_icon_gicon (ctx, drag_item.image.gicon, 32, 32);
                 }
 
                 app_launched ();

--- a/src/Widgets/AppButton.vala
+++ b/src/Widgets/AppButton.vala
@@ -40,7 +40,13 @@ public class Slingshot.Widgets.AppButton : Gtk.Button {
             wrap_mode = WORD_CHAR
         };
 
-        var image = new Gtk.Image.from_gicon (app.icon, ICON_SIZE) {
+        var icon = app.icon;
+        unowned var theme = Gtk.IconTheme.get_default ();
+        if (icon == null || theme.lookup_by_gicon (icon, ICON_SIZE, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
+            icon = new ThemedIcon ("application-default-icon");
+        }
+
+        var image = new Gtk.Image.from_gicon (icon, ICON_SIZE) {
             margin_top = 9,
             margin_end = 6,
             margin_start = 6,

--- a/src/Widgets/SearchItem.vala
+++ b/src/Widgets/SearchItem.vala
@@ -13,7 +13,7 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
     public string search_term { get; construct; }
     public ResultType result_type { public get; construct; }
 
-    public Gtk.Image icon { public get; private set; }
+    public Gtk.Image image { public get; private set; }
     public string? app_uri { get; private set; }
 
     private Gtk.Label name_label;
@@ -43,8 +43,14 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
             xalign = 0
         };
 
-        icon = new Gtk.Image () {
-            gicon = app.icon,
+        var icon = app.icon;
+        unowned var theme = Gtk.IconTheme.get_default ();
+        if (icon == null || theme.lookup_by_gicon (icon, ICON_SIZE, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
+            icon = new ThemedIcon ("application-default-icon");
+        }
+
+        image = new Gtk.Image () {
+            gicon = icon,
             pixel_size = ICON_SIZE
         };
 
@@ -53,7 +59,7 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
         if (app.match != null && app.match.icon_name.has_prefix (Path.DIR_SEPARATOR_S)) {
             var pixbuf = Backend.SynapseSearch.get_pathicon_for_match (app.match, ICON_SIZE);
             if (pixbuf != null) {
-                icon.set_from_pixbuf (pixbuf);
+                image.set_from_pixbuf (pixbuf);
             }
         }
 
@@ -63,7 +69,7 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
             margin_bottom = 6,
             margin_start = 18
         };
-        box.add (icon);
+        box.add (image);
         box.add (name_label);
 
         child = box;


### PR DESCRIPTION
in GTK4, `lookup_by_gicon` requires us to specify a scale and text direction, which the app system has no concept of. Move these lookups to widgets since that's where we'll know the size, scale, and text direction required