### PR TITLE
AppContextMenu: use dialog response/present

### DIFF
--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -188,8 +188,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
                     Gtk.ButtonsType.CLOSE
                 );
                 message_dialog.show_error_details (error.message);
-                message_dialog.run ();
-                message_dialog.destroy ();
+                message_dialog.response.connect (message_dialog.destroy);
+                message_dialog.present ();
             } finally {
                 app_launched ();
             }


### PR DESCRIPTION
no `run` in GTK4