### PR TITLE
Style listitems as modelbuttons

### DIFF
--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -7,7 +7,6 @@
 public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
     public SlingshotView view { get; construct; }
 
-    private bool dragging = false;
     private string? drag_uri = null;
     private Gtk.ListBox category_switcher;
     private Gtk.ListBox listbox;
@@ -70,10 +69,8 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
         listbox.row_activated.connect ((row) => {
             Idle.add (() => {
-                if (!dragging) {
-                    ((AppListRow) row).launch ();
-                    view.close_indicator ();
-                }
+                ((AppListRow) row).launch ();
+                view.close_indicator ();
 
                 return false;
             });
@@ -121,19 +118,9 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
         Gtk.drag_source_set (listbox, Gdk.ModifierType.BUTTON1_MASK, {DND}, Gdk.DragAction.COPY);
 
-        listbox.motion_notify_event.connect ((event) => {
-            if (!dragging) {
-                listbox.select_row (listbox.get_row_at_y ((int) event.y));
-            }
-
-            return Gdk.EVENT_PROPAGATE;
-        });
-
         listbox.drag_begin.connect ((ctx) => {
             unowned Gtk.ListBoxRow? selected_row = listbox.get_selected_row ();
             if (selected_row != null) {
-                dragging = true;
-
                 var drag_item = (AppListRow) selected_row;
                 drag_uri = "file://" + drag_item.desktop_path;
                 if (drag_uri != null) {
@@ -149,7 +136,6 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
                 view.close_indicator ();
             }
 
-            dragging = false;
             drag_uri = null;
         });
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -78,7 +78,6 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
     private Granite.Widgets.AlertView alert_view;
     private Gtk.ListBox list_box;
     Gee.HashMap<ResultType, uint> limitator;
-    private bool dragging { get; private set; default = false; }
     private string? drag_uri = null;
 
     private Gtk.GestureMultiPress click_controller;
@@ -104,19 +103,9 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
         list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) update_header);
         list_box.set_placeholder (alert_view);
 
-        list_box.motion_notify_event.connect ((event) => {
-            if (!dragging) {
-                list_box.select_row (list_box.get_row_at_y ((int) event.y));
-            }
-
-            return Gdk.EVENT_PROPAGATE;
-        });
-
         list_box.drag_begin.connect ((ctx) => {
             var selected_row = list_box.get_selected_row ();
             if (selected_row != null) {
-                dragging = true;
-
                 var drag_item = (Slingshot.Widgets.SearchItem) selected_row;
                 drag_uri = drag_item.app_uri;
                 if (drag_uri != null) {
@@ -132,7 +121,6 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
                 app_launched ();
             }
 
-            dragging = false;
             drag_uri = null;
         });
 
@@ -147,21 +135,19 @@ public class Slingshot.Widgets.SearchView : Gtk.ScrolledWindow {
         list_box.row_activated.connect ((row) => {
             Idle.add (() => {
                 var search_item = row as SearchItem;
-                if (!dragging) {
-                    switch (search_item.result_type) {
-                        case ResultType.APP_ACTIONS:
-                        case ResultType.LINK:
-                        case ResultType.SETTINGS:
-                        case ResultType.BOOKMARK:
-                            search_item.app.match.execute (null);
-                            break;
-                        default:
-                            search_item.app.launch ();
-                            break;
-                    }
-
-                    app_launched ();
+                switch (search_item.result_type) {
+                    case ResultType.APP_ACTIONS:
+                    case ResultType.LINK:
+                    case ResultType.SETTINGS:
+                    case ResultType.BOOKMARK:
+                        search_item.app.match.execute (null);
+                        break;
+                    default:
+                        search_item.app.launch ();
+                        break;
                 }
+
+                app_launched ();
 
                 return false;
             });

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -15,6 +15,10 @@ public class AppListRow : Gtk.ListBoxRow {
         );
     }
 
+    class construct {
+        set_css_name ("modelbutton");
+    }
+
     construct {
         app_info = new GLib.DesktopAppInfo (app_id);
 
@@ -36,12 +40,7 @@ public class AppListRow : Gtk.ListBoxRow {
 
         tooltip_text = app_info.get_description ();
 
-        var box = new Gtk.Box (HORIZONTAL, 12) {
-            margin_top = 6,
-            margin_start = 18,
-            margin_end = 6,
-            margin_bottom = 6
-        };
+        var box = new Gtk.Box (HORIZONTAL, 12);
         box.add (image);
         box.add (name_label);
 

--- a/src/Widgets/SearchItem.vala
+++ b/src/Widgets/SearchItem.vala
@@ -26,6 +26,10 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
         );
     }
 
+    class construct {
+        set_css_name ("modelbutton");
+    }
+
     construct {
         string markup;
         if (result_type == ResultType.TEXT) {
@@ -63,10 +67,7 @@ public class Slingshot.Widgets.SearchItem : Gtk.ListBoxRow {
         }
 
         var box = new Gtk.Box (HORIZONTAL, 12) {
-            margin_top = 6,
-            margin_end = 6,
-            margin_bottom = 6,
-            margin_start = 18
+            margin_start = 6
         };
         box.add (image);
         box.add (name_label);


### PR DESCRIPTION
Remove this motion event hack to style list items as modelbuttons and just do it with CSS

Dragging closes the indicator so we don't need to check for dragging when activating rows etc