### PR TITLE
Styles: add modelbutton focus style

### DIFF
--- a/data/PageChecker.css
+++ b/data/PageChecker.css
@@ -1,3 +1,7 @@
+modelbutton:focus {
+    background: alpha(@fg_color, 0.1);
+}
+
 .switcher {
     background-color: transparent;
     border: none;


### PR DESCRIPTION
Fixes a regression introduced in #666 

Turns out we don't have keyboard focus styles for modelbuttons in GTK3