### PR TITLE
current_event_time → Gdk.CURRENT_TIME

### DIFF
--- a/src/Backend/App.vala
+++ b/src/Backend/App.vala
@@ -127,7 +127,7 @@ public class Slingshot.Backend.App : Object {
                     launched (this); // Emit launched signal
 
                     var context = Gdk.Display.get_default ().get_app_launch_context ();
-                    context.set_timestamp (Gtk.get_current_event_time ());
+                    context.set_timestamp (Gdk.CURRENT_TIME);
                     switcheroo_control.apply_gpu_environment (context, prefers_default_gpu);
 
                     new DesktopAppInfo (desktop_id).launch (null, context);

--- a/src/synapse-plugins/desktop-file-plugin.vala
+++ b/src/synapse-plugins/desktop-file-plugin.vala
@@ -62,7 +62,7 @@ namespace Synapse {
 
             public override void execute (Match? match) {
                 var context = Gdk.Display.get_default ().get_app_launch_context ();
-                context.set_timestamp (Gtk.get_current_event_time ());
+                context.set_timestamp (Gdk.CURRENT_TIME);
                 ((DesktopAppInfo) app_info).launch_action (action_name, context);
             }
         }


### PR DESCRIPTION
no `Gtk.get_current_event_time ()` in GTK4