### PR TITLE
Replace chaining signals with get_ancestor.popdown

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -49,18 +49,12 @@ public class Slingshot.Indicator : Wingpanel.Indicator {
         default_theme.add_resource_path ("/io/elementary/desktop/wingpanel/applications-menu/icons");
     }
 
-    private void on_close_indicator () {
-        close ();
-    }
-
     public override Gtk.Widget? get_widget () {
         if (view == null) {
             view = new SlingshotView ();
 
             unowned var unity_client = Unity.get_default ();
             unity_client.add_client (view);
-
-            view.close_indicator.connect (on_close_indicator);
 
             if (dbus_service == null) {
                 dbus_service = new DBusService (view);

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -5,8 +5,6 @@
  */
 
 public class Slingshot.SlingshotView : Gtk.Bin, UnityClient {
-    public signal void close_indicator ();
-
     public Backend.AppSystem app_system;
     public Gtk.SearchEntry search_entry;
     public Gtk.Stack stack;
@@ -142,14 +140,6 @@ public class Slingshot.SlingshotView : Gtk.Bin, UnityClient {
 
         search_entry.activate.connect (search_entry_activated);
 
-        grid_view.app_launched.connect (() => {
-            close_indicator ();
-        });
-
-        search_view.app_launched.connect (() => {
-            close_indicator ();
-        });
-
         // Auto-update applications grid
         app_system.changed.connect (() => {
             grid_view.populate (app_system);
@@ -223,7 +213,7 @@ public class Slingshot.SlingshotView : Gtk.Bin, UnityClient {
                 if (search_entry.text.length > 0) {
                     search_entry.text = "";
                 } else {
-                    close_indicator ();
+                    ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
                 }
 
                 return Gdk.EVENT_STOP;
@@ -247,7 +237,7 @@ public class Slingshot.SlingshotView : Gtk.Bin, UnityClient {
         if ((state & Gdk.ModifierType.MOD1_MASK) != 0) {
             switch (keyval) {
                 case Gdk.Key.F4:
-                    close_indicator ();
+                    ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
                     return Gdk.EVENT_STOP;
 
                 case Gdk.Key.@0:

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -70,7 +70,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
         listbox.row_activated.connect ((row) => {
             Idle.add (() => {
                 ((AppListRow) row).launch ();
-                view.close_indicator ();
+                ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
 
                 return false;
             });
@@ -127,13 +127,13 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
                     Gtk.drag_set_icon_gicon (ctx, drag_item.app_info.get_icon (), 32, 32);
                 }
 
-                view.close_indicator ();
+                ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
             }
         });
 
         listbox.drag_end.connect (() => {
             if (drag_uri != null) {
-                view.close_indicator ();
+                ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
             }
 
             drag_uri = null;

--- a/src/Views/GridView.vala
+++ b/src/Views/GridView.vala
@@ -5,8 +5,6 @@
  */
 
 public class Slingshot.Widgets.Grid : Gtk.Box {
-    public signal void app_launched ();
-
     private struct Page {
         public uint rows;
         public uint columns;
@@ -112,7 +110,7 @@ public class Slingshot.Widgets.Grid : Gtk.Box {
 
         foreach (Backend.App app in app_system.get_apps_by_name ()) {
             var app_button = new Widgets.AppButton (app);
-            app_button.app_launched.connect (() => app_launched ());
+            app_button.app_launched.connect (() => ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ());
 
             if (next_col_index == page.columns) {
                 next_col_index = 0;

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -73,7 +73,6 @@ public class Slingshot.Widgets.SearchView : Gtk.Bin {
     const int MAX_RESULTS = 10;
 
     public signal void start_search (Synapse.SearchMatch search_match, Synapse.Match? target);
-    public signal void app_launched ();
 
     private Granite.Widgets.AlertView alert_view;
     private Gtk.ListBox list_box;
@@ -117,13 +116,13 @@ public class Slingshot.Widgets.SearchView : Gtk.Bin {
                     Gtk.drag_set_icon_gicon (ctx, drag_item.image.gicon, 32, 32);
                 }
 
-                app_launched ();
+                ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
             }
         });
 
         list_box.drag_end.connect (() => {
             if (drag_uri != null) {
-                app_launched ();
+                ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
             }
 
             drag_uri = null;
@@ -154,7 +153,7 @@ public class Slingshot.Widgets.SearchView : Gtk.Bin {
                         break;
                 }
 
-                app_launched ();
+                ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ();
 
                 return false;
             });
@@ -273,7 +272,7 @@ public class Slingshot.Widgets.SearchView : Gtk.Bin {
         var search_item = new SearchItem (app, search_term, result_type);
         app.start_search.connect ((search, target) => start_search (search, target));
 
-        app.launched.connect (() => app_launched ());
+        app.launched.connect (() => ((Gtk.Popover) get_ancestor (typeof (Gtk.Popover))).popdown ());
 
         list_box.add (search_item);
         search_item.show_all ();


### PR DESCRIPTION
Instead of chaining up signals and obscuring things with the signal name `app_launched`, use `get ancestor` to `popdown`